### PR TITLE
Use env variable for GDrive

### DIFF
--- a/examples/GDriveSimpleDownload.xircuits
+++ b/examples/GDriveSimpleDownload.xircuits
@@ -6,7 +6,7 @@
     "gridSize": 0,
     "layers": [
         {
-            "id": "fed19782-fba5-4ec9-98aa-2fd9cce2b67d",
+            "id": "436f691e-84eb-4dcd-8014-bbf45e8f201d",
             "type": "diagram-links",
             "isSvg": true,
             "transformed": true,
@@ -15,10 +15,10 @@
                     "id": "8e3cd1fd-ffe6-4311-9461-4dc2bc1b6183",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "9b1d4730-0e7e-4b7b-a952-df15d6ff16a5",
-                    "sourcePort": "f4e4647a-8794-4d32-90e3-57d1a30bc905",
-                    "target": "9da6d81a-307d-46d8-8bbd-95540a1b16bc",
-                    "targetPort": "f3011191-b5f9-4dd3-aec2-bbfa77207d51",
+                    "source": "8cdc91b9-1d6a-41c2-ae90-127f423149cb",
+                    "sourcePort": "8365f224-a0c7-440d-8ddf-3aa3d879cb61",
+                    "target": "ab86e314-783a-40fc-8b7b-41d3d1cd4360",
+                    "targetPort": "93933981-1a0f-42e0-83b3-71bf33fa506f",
                     "points": [
                         {
                             "id": "a663270b-fe88-49ca-9e75-9b20e012c45a",
@@ -45,13 +45,13 @@
                     "selected": false,
                     "source": "7dfa4275-f8c3-4b0f-98e5-4a0bb64b2394",
                     "sourcePort": "f5e2e54a-d02c-4e90-b955-b0efc1ee5ac7",
-                    "target": "c3cd076d-d8d8-41f3-affd-9df5071e95a5",
-                    "targetPort": "e30b8d6f-a278-4bca-9c5a-d9ee77e4ccce",
+                    "target": "7c728e58-67b5-422e-b912-df51e44d7c0f",
+                    "targetPort": "b04a5624-b57c-4b4f-a3c6-1b5fa9fb30de",
                     "points": [
                         {
                             "id": "8070a894-45b5-4c6a-8346-75d11f3dbb19",
                             "type": "point",
-                            "x": 54.38887326831144,
+                            "x": 54.38890705160826,
                             "y": 282.70833117853573
                         },
                         {
@@ -71,15 +71,15 @@
                     "id": "ce33f246-a77a-4bb1-9f20-b22f2307be8d",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "c3cd076d-d8d8-41f3-affd-9df5071e95a5",
-                    "sourcePort": "fd5775f8-f0fb-4885-aaa4-c73a6cf3c14a",
-                    "target": "9b1d4730-0e7e-4b7b-a952-df15d6ff16a5",
-                    "targetPort": "48d530dd-f190-4ceb-9ef6-d5c027505496",
+                    "source": "7c728e58-67b5-422e-b912-df51e44d7c0f",
+                    "sourcePort": "e016998b-e009-44ef-a3e4-0d3705bb0e6e",
+                    "target": "8cdc91b9-1d6a-41c2-ae90-127f423149cb",
+                    "targetPort": "05223790-60a7-4e70-a93f-94f1e8d8777d",
                     "points": [
                         {
                             "id": "58e9596c-0992-4011-97df-7b47589230fb",
                             "type": "point",
-                            "x": 466.80552987506314,
+                            "x": 496.4166571020581,
                             "y": 282.09722512240677
                         },
                         {
@@ -99,15 +99,15 @@
                     "id": "7bd42049-0589-4a35-81ee-375da1cda2d5",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "c3cd076d-d8d8-41f3-affd-9df5071e95a5",
-                    "sourcePort": "1d0d953d-5a63-4110-a438-4e48f5d9be01",
-                    "target": "9b1d4730-0e7e-4b7b-a952-df15d6ff16a5",
-                    "targetPort": "6eb8ea17-d21d-4648-8aeb-aceae333ca16",
+                    "source": "7c728e58-67b5-422e-b912-df51e44d7c0f",
+                    "sourcePort": "544da204-e5c1-4446-a4a4-6ea21935db6e",
+                    "target": "8cdc91b9-1d6a-41c2-ae90-127f423149cb",
+                    "targetPort": "11b424d9-4f97-4fbd-96da-e9cc76496b0f",
                     "points": [
                         {
                             "id": "cc9b1b4f-ddf0-468e-b385-86a245932cbe",
                             "type": "point",
-                            "x": 466.80552987506314,
+                            "x": 496.4166571020581,
                             "y": 325.6527649468327
                         },
                         {
@@ -127,10 +127,10 @@
                     "id": "95870faf-aeec-4deb-8940-a2599a3431ec",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "702b8953-46a3-4476-b865-68c70c5ac06d",
-                    "sourcePort": "ce3aec9b-4ee1-4daa-8e61-cb5e1cfc299d",
-                    "target": "9b1d4730-0e7e-4b7b-a952-df15d6ff16a5",
-                    "targetPort": "635f5911-a0b9-45af-9b6c-6191f91777c4",
+                    "source": "97285243-ac5d-4cb6-a05a-184a1c0f77b7",
+                    "sourcePort": "9ea82c93-d655-45bb-a55b-8d328a067f0c",
+                    "target": "8cdc91b9-1d6a-41c2-ae90-127f423149cb",
+                    "targetPort": "c0a8c601-c99e-45d4-ad53-92f7ac86d904",
                     "points": [
                         {
                             "id": "f9c9ffdb-5a76-4df5-a36c-af996ef7938d",
@@ -155,10 +155,10 @@
                     "id": "cc2d3657-d7a4-4361-b259-30ceafd24f6b",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "29213b77-183f-4829-84e1-322099fe8c6f",
-                    "sourcePort": "74612043-f4ea-4d48-8d69-df63205915f7",
-                    "target": "9b1d4730-0e7e-4b7b-a952-df15d6ff16a5",
-                    "targetPort": "60f510b4-7e52-4cb9-9122-1fb33a52d16e",
+                    "source": "94e1eb64-99aa-42b9-87ef-802704faf1d7",
+                    "sourcePort": "c113de04-4edd-4d32-ba43-834b4afda747",
+                    "target": "8cdc91b9-1d6a-41c2-ae90-127f423149cb",
+                    "targetPort": "9f159895-00f3-48bb-b631-137628bdfe4c",
                     "points": [
                         {
                             "id": "8aef8c89-01c2-47e4-a38c-bf93db977392",
@@ -179,23 +179,23 @@
                     "curvyness": 50,
                     "selectedColor": "rgb(0,192,255)"
                 },
-                "e94d9880-0ab7-4351-9ef1-210f46e489e9": {
-                    "id": "e94d9880-0ab7-4351-9ef1-210f46e489e9",
+                "9d9d827b-8601-4572-99cd-d4a116b949ee": {
+                    "id": "9d9d827b-8601-4572-99cd-d4a116b949ee",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "20872e7f-cdaa-4367-a960-bf1a3ad22715",
-                    "sourcePort": "42efab46-4571-493f-a1f2-48c52c16bfdd",
-                    "target": "c3cd076d-d8d8-41f3-affd-9df5071e95a5",
-                    "targetPort": "429493c5-caf5-469e-a52a-f7ea1ad3f325",
+                    "source": "b58443cf-dc99-44d2-b637-bb8d40557149",
+                    "sourcePort": "67e5b7ec-a1e9-4521-87e7-3a9be87789d0",
+                    "target": "7c728e58-67b5-422e-b912-df51e44d7c0f",
+                    "targetPort": "e45b964a-6516-4ee1-8ff0-1964e69c6514",
                     "points": [
                         {
-                            "id": "2cd6aa5f-75ca-45d5-ab5c-b51b1e24b273",
+                            "id": "e751d5b1-430b-4adf-a8c2-f11e82af134d",
                             "type": "point",
-                            "x": 267.5972526970765,
-                            "y": 362.24997390598287
+                            "x": 262.06219734652285,
+                            "y": 402.10237242996834
                         },
                         {
-                            "id": "6b123c4a-82d2-4ff0-96bf-a36dc058b981",
+                            "id": "1e706f79-c198-4fb2-bf5b-2b3308b23b75",
                             "type": "point",
                             "x": 318.3611155603145,
                             "y": 303.8749855330675
@@ -210,7 +210,7 @@
             }
         },
         {
-            "id": "7fd183fe-13f0-4ab5-b1ac-d885d6030203",
+            "id": "4a96c0a3-18c3-4580-a59f-c3ae8a15286a",
             "type": "diagram-nodes",
             "isSvg": false,
             "transformed": true,
@@ -230,7 +230,7 @@
                             "id": "f5e2e54a-d02c-4e90-b955-b0efc1ee5ac7",
                             "type": "default",
                             "extras": {},
-                            "x": 43.99998374442169,
+                            "x": 44.00001752771851,
                             "y": 272.31944165464597,
                             "name": "out-0",
                             "alignment": "right",
@@ -252,8 +252,8 @@
                         "f5e2e54a-d02c-4e90-b955-b0efc1ee5ac7"
                     ]
                 },
-                "9b1d4730-0e7e-4b7b-a952-df15d6ff16a5": {
-                    "id": "9b1d4730-0e7e-4b7b-a952-df15d6ff16a5",
+                "8cdc91b9-1d6a-41c2-ae90-127f423149cb": {
+                    "id": "8cdc91b9-1d6a-41c2-ae90-127f423149cb",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -265,20 +265,21 @@
                                 "lineno": 171,
                                 "end_lineno": 193
                             }
-                        ]
+                        ],
+                        "nextNode": "None"
                     },
                     "x": 773.6650200515213,
                     "y": 241.0989101858943,
                     "ports": [
                         {
-                            "id": "48d530dd-f190-4ceb-9ef6-d5c027505496",
+                            "id": "05223790-60a7-4e70-a93f-94f1e8d8777d",
                             "type": "default",
                             "extras": {},
                             "x": 774.5415817934589,
                             "y": 267.98609195518213,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "9b1d4730-0e7e-4b7b-a952-df15d6ff16a5",
+                            "parentNode": "8cdc91b9-1d6a-41c2-ae90-127f423149cb",
                             "links": [
                                 "ce33f246-a77a-4bb1-9f20-b22f2307be8d"
                             ],
@@ -289,14 +290,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "6eb8ea17-d21d-4648-8aeb-aceae333ca16",
+                            "id": "11b424d9-4f97-4fbd-96da-e9cc76496b0f",
                             "type": "default",
                             "extras": {},
                             "x": 774.5415817934589,
                             "y": 289.76385236584287,
                             "name": "parameter-any-gdrive",
                             "alignment": "left",
-                            "parentNode": "9b1d4730-0e7e-4b7b-a952-df15d6ff16a5",
+                            "parentNode": "8cdc91b9-1d6a-41c2-ae90-127f423149cb",
                             "links": [
                                 "7bd42049-0589-4a35-81ee-375da1cda2d5"
                             ],
@@ -307,14 +308,14 @@
                             "dataType": "any"
                         },
                         {
-                            "id": "635f5911-a0b9-45af-9b6c-6191f91777c4",
+                            "id": "c0a8c601-c99e-45d4-ad53-92f7ac86d904",
                             "type": "default",
                             "extras": {},
                             "x": 774.5415817934589,
                             "y": 311.5416465598004,
                             "name": "parameter-string-file_id",
                             "alignment": "left",
-                            "parentNode": "9b1d4730-0e7e-4b7b-a952-df15d6ff16a5",
+                            "parentNode": "8cdc91b9-1d6a-41c2-ae90-127f423149cb",
                             "links": [
                                 "95870faf-aeec-4deb-8940-a2599a3431ec"
                             ],
@@ -325,14 +326,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "60f510b4-7e52-4cb9-9122-1fb33a52d16e",
+                            "id": "9f159895-00f3-48bb-b631-137628bdfe4c",
                             "type": "default",
                             "extras": {},
                             "x": 774.5415817934589,
                             "y": 333.3194069704612,
                             "name": "parameter-string-output_path",
                             "alignment": "left",
-                            "parentNode": "9b1d4730-0e7e-4b7b-a952-df15d6ff16a5",
+                            "parentNode": "8cdc91b9-1d6a-41c2-ae90-127f423149cb",
                             "links": [
                                 "cc2d3657-d7a4-4361-b259-30ceafd24f6b"
                             ],
@@ -343,14 +344,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "f4e4647a-8794-4d32-90e3-57d1a30bc905",
+                            "id": "8365f224-a0c7-440d-8ddf-3aa3d879cb61",
                             "type": "default",
                             "extras": {},
                             "x": 957.9583974069277,
                             "y": 267.98609195518213,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "9b1d4730-0e7e-4b7b-a952-df15d6ff16a5",
+                            "parentNode": "8cdc91b9-1d6a-41c2-ae90-127f423149cb",
                             "links": [
                                 "8e3cd1fd-ffe6-4311-9461-4dc2bc1b6183"
                             ],
@@ -364,17 +365,17 @@
                     "name": "DownloadFileFromGDrive",
                     "color": "rgb(255,204,0)",
                     "portsInOrder": [
-                        "48d530dd-f190-4ceb-9ef6-d5c027505496",
-                        "6eb8ea17-d21d-4648-8aeb-aceae333ca16",
-                        "635f5911-a0b9-45af-9b6c-6191f91777c4",
-                        "60f510b4-7e52-4cb9-9122-1fb33a52d16e"
+                        "05223790-60a7-4e70-a93f-94f1e8d8777d",
+                        "11b424d9-4f97-4fbd-96da-e9cc76496b0f",
+                        "c0a8c601-c99e-45d4-ad53-92f7ac86d904",
+                        "9f159895-00f3-48bb-b631-137628bdfe4c"
                     ],
                     "portsOutOrder": [
-                        "f4e4647a-8794-4d32-90e3-57d1a30bc905"
+                        "8365f224-a0c7-440d-8ddf-3aa3d879cb61"
                     ]
                 },
-                "c3cd076d-d8d8-41f3-affd-9df5071e95a5": {
-                    "id": "c3cd076d-d8d8-41f3-affd-9df5071e95a5",
+                "7c728e58-67b5-422e-b912-df51e44d7c0f": {
+                    "id": "7c728e58-67b5-422e-b912-df51e44d7c0f",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -393,14 +394,14 @@
                     "y": 244.82992123110927,
                     "ports": [
                         {
-                            "id": "e30b8d6f-a278-4bca-9c5a-d9ee77e4ccce",
+                            "id": "b04a5624-b57c-4b4f-a3c6-1b5fa9fb30de",
                             "type": "default",
                             "extras": {},
                             "x": 307.97222603642473,
                             "y": 271.708335598517,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "c3cd076d-d8d8-41f3-affd-9df5071e95a5",
+                            "parentNode": "7c728e58-67b5-422e-b912-df51e44d7c0f",
                             "links": [
                                 "ef011720-f857-4023-9190-b624affd8e38"
                             ],
@@ -411,32 +412,32 @@
                             "dataType": ""
                         },
                         {
-                            "id": "429493c5-caf5-469e-a52a-f7ea1ad3f325",
+                            "id": "e45b964a-6516-4ee1-8ff0-1964e69c6514",
                             "type": "default",
                             "extras": {},
                             "x": 307.97222603642473,
                             "y": 293.48609600917774,
-                            "name": "parameter-string-json_path",
+                            "name": "parameter-string-service_json_path",
                             "alignment": "left",
-                            "parentNode": "c3cd076d-d8d8-41f3-affd-9df5071e95a5",
+                            "parentNode": "7c728e58-67b5-422e-b912-df51e44d7c0f",
                             "links": [
-                                "e94d9880-0ab7-4351-9ef1-210f46e489e9"
+                                "9d9d827b-8601-4572-99cd-d4a116b949ee"
                             ],
                             "in": true,
-                            "label": "json_path",
-                            "varName": "json_path",
+                            "label": "★service_json_path",
+                            "varName": "★service_json_path",
                             "portType": "",
                             "dataType": "string"
                         },
                         {
-                            "id": "fd5775f8-f0fb-4885-aaa4-c73a6cf3c14a",
+                            "id": "e016998b-e009-44ef-a3e4-0d3705bb0e6e",
                             "type": "default",
                             "extras": {},
-                            "x": 456.4166403511734,
+                            "x": 486.0277675781683,
                             "y": 271.708335598517,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "c3cd076d-d8d8-41f3-affd-9df5071e95a5",
+                            "parentNode": "7c728e58-67b5-422e-b912-df51e44d7c0f",
                             "links": [
                                 "ce33f246-a77a-4bb1-9f20-b22f2307be8d"
                             ],
@@ -447,14 +448,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "900f13bd-f988-428a-a3e7-ceb351d879a2",
+                            "id": "66e0b3ef-a091-4f6e-83e0-4ad5c57423af",
                             "type": "default",
                             "extras": {},
-                            "x": 456.4166403511734,
+                            "x": 486.0277675781683,
                             "y": 293.48609600917774,
                             "name": "parameter-out-any-gauth",
                             "alignment": "right",
-                            "parentNode": "c3cd076d-d8d8-41f3-affd-9df5071e95a5",
+                            "parentNode": "7c728e58-67b5-422e-b912-df51e44d7c0f",
                             "links": [],
                             "in": false,
                             "label": "gauth",
@@ -463,14 +464,14 @@
                             "dataType": "any"
                         },
                         {
-                            "id": "1d0d953d-5a63-4110-a438-4e48f5d9be01",
+                            "id": "544da204-e5c1-4446-a4a4-6ea21935db6e",
                             "type": "default",
                             "extras": {},
-                            "x": 456.4166403511734,
+                            "x": 486.0277675781683,
                             "y": 315.2638902031353,
                             "name": "parameter-out-any-gdrive",
                             "alignment": "right",
-                            "parentNode": "c3cd076d-d8d8-41f3-affd-9df5071e95a5",
+                            "parentNode": "7c728e58-67b5-422e-b912-df51e44d7c0f",
                             "links": [
                                 "7bd42049-0589-4a35-81ee-375da1cda2d5"
                             ],
@@ -484,17 +485,17 @@
                     "name": "GDriveServiceAuth",
                     "color": "rgb(15,255,255)",
                     "portsInOrder": [
-                        "e30b8d6f-a278-4bca-9c5a-d9ee77e4ccce",
-                        "429493c5-caf5-469e-a52a-f7ea1ad3f325"
+                        "b04a5624-b57c-4b4f-a3c6-1b5fa9fb30de",
+                        "e45b964a-6516-4ee1-8ff0-1964e69c6514"
                     ],
                     "portsOutOrder": [
-                        "fd5775f8-f0fb-4885-aaa4-c73a6cf3c14a",
-                        "900f13bd-f988-428a-a3e7-ceb351d879a2",
-                        "1d0d953d-5a63-4110-a438-4e48f5d9be01"
+                        "e016998b-e009-44ef-a3e4-0d3705bb0e6e",
+                        "66e0b3ef-a091-4f6e-83e0-4ad5c57423af",
+                        "544da204-e5c1-4446-a4a4-6ea21935db6e"
                     ]
                 },
-                "9da6d81a-307d-46d8-8bbd-95540a1b16bc": {
-                    "id": "9da6d81a-307d-46d8-8bbd-95540a1b16bc",
+                "ab86e314-783a-40fc-8b7b-41d3d1cd4360": {
+                    "id": "ab86e314-783a-40fc-8b7b-41d3d1cd4360",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -504,14 +505,14 @@
                     "y": 246.20620851272977,
                     "ports": [
                         {
-                            "id": "f3011191-b5f9-4dd3-aec2-bbfa77207d51",
+                            "id": "93933981-1a0f-42e0-83b3-71bf33fa506f",
                             "type": "default",
                             "extras": {},
                             "x": 1067.6389785877395,
                             "y": 273.08331577898286,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "9da6d81a-307d-46d8-8bbd-95540a1b16bc",
+                            "parentNode": "ab86e314-783a-40fc-8b7b-41d3d1cd4360",
                             "links": [
                                 "8e3cd1fd-ffe6-4311-9461-4dc2bc1b6183"
                             ],
@@ -522,14 +523,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "e2e39f46-b21f-4b65-9bdb-fc4d6a9ba86e",
+                            "id": "f292b680-3964-4813-9783-eb1447eda5aa",
                             "type": "default",
                             "extras": {},
                             "x": 1067.6389785877395,
                             "y": 294.8610761896436,
                             "name": "parameter-dynalist-outputs",
                             "alignment": "left",
-                            "parentNode": "9da6d81a-307d-46d8-8bbd-95540a1b16bc",
+                            "parentNode": "ab86e314-783a-40fc-8b7b-41d3d1cd4360",
                             "links": [],
                             "in": true,
                             "label": "outputs",
@@ -546,13 +547,13 @@
                     "name": "Finish",
                     "color": "rgb(255,102,102)",
                     "portsInOrder": [
-                        "f3011191-b5f9-4dd3-aec2-bbfa77207d51",
-                        "e2e39f46-b21f-4b65-9bdb-fc4d6a9ba86e"
+                        "93933981-1a0f-42e0-83b3-71bf33fa506f",
+                        "f292b680-3964-4813-9783-eb1447eda5aa"
                     ],
                     "portsOutOrder": []
                 },
-                "702b8953-46a3-4476-b865-68c70c5ac06d": {
-                    "id": "702b8953-46a3-4476-b865-68c70c5ac06d",
+                "97285243-ac5d-4cb6-a05a-184a1c0f77b7": {
+                    "id": "97285243-ac5d-4cb6-a05a-184a1c0f77b7",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -562,14 +563,14 @@
                     "y": 413.6637303239172,
                     "ports": [
                         {
-                            "id": "ce3aec9b-4ee1-4daa-8e61-cb5e1cfc299d",
+                            "id": "9ea82c93-d655-45bb-a55b-8d328a067f0c",
                             "type": "default",
                             "extras": {},
                             "x": 670.97212874053,
                             "y": 437.98607393742384,
                             "name": "parameter-out-0",
                             "alignment": "right",
-                            "parentNode": "702b8953-46a3-4476-b865-68c70c5ac06d",
+                            "parentNode": "97285243-ac5d-4cb6-a05a-184a1c0f77b7",
                             "links": [
                                 "95870faf-aeec-4deb-8940-a2599a3431ec"
                             ],
@@ -584,31 +585,31 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "ce3aec9b-4ee1-4daa-8e61-cb5e1cfc299d"
+                        "9ea82c93-d655-45bb-a55b-8d328a067f0c"
                     ]
                 },
-                "20872e7f-cdaa-4367-a960-bf1a3ad22715": {
-                    "id": "20872e7f-cdaa-4367-a960-bf1a3ad22715",
+                "b58443cf-dc99-44d2-b637-bb8d40557149": {
+                    "id": "b58443cf-dc99-44d2-b637-bb8d40557149",
                     "type": "custom-node",
-                    "selected": false,
+                    "selected": true,
                     "extras": {
                         "type": "string",
                         "borderColor": "rgb(0,192,255)"
                     },
-                    "x": 73.15536905491525,
-                    "y": 327.52821187995295,
+                    "x": 67.62031370436175,
+                    "y": 367.3806104039382,
                     "ports": [
                         {
-                            "id": "42efab46-4571-493f-a1f2-48c52c16bfdd",
+                            "id": "67e5b7ec-a1e9-4521-87e7-3a9be87789d0",
                             "type": "default",
                             "extras": {},
-                            "x": 257.20836317318674,
-                            "y": 351.8610991622855,
+                            "x": 251.67330782263326,
+                            "y": 391.7134976862709,
                             "name": "parameter-out-0",
                             "alignment": "right",
-                            "parentNode": "20872e7f-cdaa-4367-a960-bf1a3ad22715",
+                            "parentNode": "b58443cf-dc99-44d2-b637-bb8d40557149",
                             "links": [
-                                "e94d9880-0ab7-4351-9ef1-210f46e489e9"
+                                "9d9d827b-8601-4572-99cd-d4a116b949ee"
                             ],
                             "in": false,
                             "label": "▶",
@@ -621,11 +622,11 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "42efab46-4571-493f-a1f2-48c52c16bfdd"
+                        "67e5b7ec-a1e9-4521-87e7-3a9be87789d0"
                     ]
                 },
-                "29213b77-183f-4829-84e1-322099fe8c6f": {
-                    "id": "29213b77-183f-4829-84e1-322099fe8c6f",
+                "94e1eb64-99aa-42b9-87ef-802704faf1d7": {
+                    "id": "94e1eb64-99aa-42b9-87ef-802704faf1d7",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -636,14 +637,14 @@
                     "y": 503.6838707094618,
                     "ports": [
                         {
-                            "id": "74612043-f4ea-4d48-8d69-df63205915f7",
+                            "id": "c113de04-4edd-4d32-ba43-834b4afda747",
                             "type": "default",
                             "extras": {},
                             "x": 655.0693849962956,
                             "y": 528.0139316439795,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "29213b77-183f-4829-84e1-322099fe8c6f",
+                            "parentNode": "94e1eb64-99aa-42b9-87ef-802704faf1d7",
                             "links": [
                                 "cc2d3657-d7a4-4361-b259-30ceafd24f6b"
                             ],
@@ -658,7 +659,7 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "74612043-f4ea-4d48-8d69-df63205915f7"
+                        "c113de04-4edd-4d32-ba43-834b4afda747"
                     ]
                 }
             }

--- a/examples/GDriveSimpleDownload.xircuits
+++ b/examples/GDriveSimpleDownload.xircuits
@@ -1,12 +1,12 @@
 {
     "id": "d2092cf3-22a9-47c0-b0a7-7a89dada01e2",
-    "offsetX": 51.81496300777346,
-    "offsetY": -27.828847125425938,
+    "offsetX": 77.81496300777346,
+    "offsetY": -2.8288471254259377,
     "zoom": 90.33333333333331,
     "gridSize": 0,
     "layers": [
         {
-            "id": "fe47ef17-7576-485b-a940-6570cd5444d1",
+            "id": "fed19782-fba5-4ec9-98aa-2fd9cce2b67d",
             "type": "diagram-links",
             "isSvg": true,
             "transformed": true,
@@ -15,22 +15,22 @@
                     "id": "8e3cd1fd-ffe6-4311-9461-4dc2bc1b6183",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "192239b1-184c-4107-a978-b7303dcb23e9",
-                    "sourcePort": "09f11514-0df2-4e25-81d1-6e1dc03fed10",
-                    "target": "9e89d907-197c-4462-8fc6-8b8ab3650f56",
-                    "targetPort": "a5f75c51-418d-480b-8f9b-30fbe7d78f24",
+                    "source": "9b1d4730-0e7e-4b7b-a952-df15d6ff16a5",
+                    "sourcePort": "f4e4647a-8794-4d32-90e3-57d1a30bc905",
+                    "target": "9da6d81a-307d-46d8-8bbd-95540a1b16bc",
+                    "targetPort": "f3011191-b5f9-4dd3-aec2-bbfa77207d51",
                     "points": [
                         {
                             "id": "a663270b-fe88-49ca-9e75-9b20e012c45a",
                             "type": "point",
-                            "x": 937.5000035358032,
-                            "y": 280.41248061478257
+                            "x": 968.3472563147047,
+                            "y": 278.3749814790719
                         },
                         {
                             "id": "85dd3306-6fa0-4acf-b36e-c8efa500f767",
                             "type": "point",
-                            "x": 998.149940113294,
-                            "y": 279.9749731965336
+                            "x": 1078.0278374955165,
+                            "y": 283.4722053028726
                         }
                     ],
                     "labels": [],
@@ -45,20 +45,20 @@
                     "selected": false,
                     "source": "7dfa4275-f8c3-4b0f-98e5-4a0bb64b2394",
                     "sourcePort": "f5e2e54a-d02c-4e90-b955-b0efc1ee5ac7",
-                    "target": "5911eff8-f9e4-4065-9b70-e018f087a362",
-                    "targetPort": "6e9ae455-fc97-44ad-b3df-bcacd9418aa9",
+                    "target": "c3cd076d-d8d8-41f3-affd-9df5071e95a5",
+                    "targetPort": "e30b8d6f-a278-4bca-9c5a-d9ee77e4ccce",
                     "points": [
                         {
                             "id": "8070a894-45b5-4c6a-8346-75d11f3dbb19",
                             "type": "point",
-                            "x": 54.41250257297912,
-                            "y": 282.531977090509
+                            "x": 54.38887326831144,
+                            "y": 282.70833117853573
                         },
                         {
                             "id": "26c13e98-99b6-494c-b97d-15d0a3a65c38",
                             "type": "point",
-                            "x": 318.18748419486565,
-                            "y": 281.92499259659184
+                            "x": 318.3611155603145,
+                            "y": 282.09722512240677
                         }
                     ],
                     "labels": [],
@@ -71,22 +71,22 @@
                     "id": "ce33f246-a77a-4bb1-9f20-b22f2307be8d",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "5911eff8-f9e4-4065-9b70-e018f087a362",
-                    "sourcePort": "0ade9252-8b85-44d7-80a2-b0699b8f0ce1",
-                    "target": "192239b1-184c-4107-a978-b7303dcb23e9",
-                    "targetPort": "b801fdd0-3795-497b-8776-db00e607728f",
+                    "source": "c3cd076d-d8d8-41f3-affd-9df5071e95a5",
+                    "sourcePort": "fd5775f8-f0fb-4885-aaa4-c73a6cf3c14a",
+                    "target": "9b1d4730-0e7e-4b7b-a952-df15d6ff16a5",
+                    "targetPort": "48d530dd-f190-4ceb-9ef6-d5c027505496",
                     "points": [
                         {
                             "id": "58e9596c-0992-4011-97df-7b47589230fb",
                             "type": "point",
-                            "x": 496.2250129050375,
-                            "y": 281.92499259659184
+                            "x": 466.80552987506314,
+                            "y": 282.09722512240677
                         },
                         {
                             "id": "a5233b9c-81f8-40e4-9895-31b070e9a301",
                             "type": "point",
-                            "x": 753.7625168689444,
-                            "y": 280.41248061478257
+                            "x": 784.9305008777334,
+                            "y": 278.3749814790719
                         }
                     ],
                     "labels": [],
@@ -99,22 +99,22 @@
                     "id": "7bd42049-0589-4a35-81ee-375da1cda2d5",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "5911eff8-f9e4-4065-9b70-e018f087a362",
-                    "sourcePort": "01b3be47-9f77-440a-a145-587dddc08733",
-                    "target": "192239b1-184c-4107-a978-b7303dcb23e9",
-                    "targetPort": "c157120a-0189-440b-a19f-29a443ebf671",
+                    "source": "c3cd076d-d8d8-41f3-affd-9df5071e95a5",
+                    "sourcePort": "1d0d953d-5a63-4110-a438-4e48f5d9be01",
+                    "target": "9b1d4730-0e7e-4b7b-a952-df15d6ff16a5",
+                    "targetPort": "6eb8ea17-d21d-4648-8aeb-aceae333ca16",
                     "points": [
                         {
                             "id": "cc9b1b4f-ddf0-468e-b385-86a245932cbe",
                             "type": "point",
-                            "x": 496.2250129050375,
-                            "y": 325.1250117855044
+                            "x": 466.80552987506314,
+                            "y": 325.6527649468327
                         },
                         {
                             "id": "05fc200c-09dd-4691-9785-2db1263c8924",
                             "type": "point",
-                            "x": 753.7625168689444,
-                            "y": 302.0125071008872
+                            "x": 784.9305008777334,
+                            "y": 300.1527418897326
                         }
                     ],
                     "labels": [],
@@ -127,50 +127,22 @@
                     "id": "95870faf-aeec-4deb-8940-a2599a3431ec",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "4ae287b2-9955-4d15-a8ed-be66d362f421",
-                    "sourcePort": "ea53b171-3185-409f-b428-a076764a5e3c",
-                    "target": "192239b1-184c-4107-a978-b7303dcb23e9",
-                    "targetPort": "4ad28ca3-ae00-4374-b691-3708da9e40e2",
+                    "source": "702b8953-46a3-4476-b865-68c70c5ac06d",
+                    "sourcePort": "ce3aec9b-4ee1-4daa-8e61-cb5e1cfc299d",
+                    "target": "9b1d4730-0e7e-4b7b-a952-df15d6ff16a5",
+                    "targetPort": "635f5911-a0b9-45af-9b6c-6191f91777c4",
                     "points": [
                         {
                             "id": "f9c9ffdb-5a76-4df5-a36c-af996ef7938d",
                             "type": "point",
-                            "x": 677.0750549173824,
-                            "y": 375.799990794816
+                            "x": 681.3610478248045,
+                            "y": 448.3749634613136
                         },
                         {
                             "id": "220d2d76-f98f-449e-a27c-54b4ad961a96",
                             "type": "point",
-                            "x": 753.7625168689444,
-                            "y": 323.6124660203983
-                        }
-                    ],
-                    "labels": [],
-                    "width": 3,
-                    "color": "gray",
-                    "curvyness": 50,
-                    "selectedColor": "rgb(0,192,255)"
-                },
-                "38bb5b47-9a41-4f30-a005-918727db3d8c": {
-                    "id": "38bb5b47-9a41-4f30-a005-918727db3d8c",
-                    "type": "triangle-link",
-                    "selected": false,
-                    "source": "3a32b75c-5419-4628-9791-41898a373e21",
-                    "sourcePort": "48db060f-ac44-4b82-9a24-eadb21aca214",
-                    "target": "5911eff8-f9e4-4065-9b70-e018f087a362",
-                    "targetPort": "946c5cc0-c7e4-460f-a501-912d8e3989f8",
-                    "points": [
-                        {
-                            "id": "f7f49697-78a5-4ae8-9075-bff75e889eb4",
-                            "type": "point",
-                            "x": 267.79996725817296,
-                            "y": 361.6249924164142
-                        },
-                        {
-                            "id": "088c35c8-16e8-4d64-a109-6f8fb5b7a213",
-                            "type": "point",
-                            "x": 318.18748419486565,
-                            "y": 303.5249852993997
+                            "x": 784.9305008777334,
+                            "y": 321.9305360836902
                         }
                     ],
                     "labels": [],
@@ -183,22 +155,50 @@
                     "id": "cc2d3657-d7a4-4361-b259-30ceafd24f6b",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "a9e76731-5270-4184-8a1c-3537ffcc84cb",
-                    "sourcePort": "bc0c2e3d-3f9d-4f90-bfff-30666f985169",
-                    "target": "192239b1-184c-4107-a978-b7303dcb23e9",
-                    "targetPort": "471d79fb-e33e-4248-83cd-24bf35ee9785",
+                    "source": "29213b77-183f-4829-84e1-322099fe8c6f",
+                    "sourcePort": "74612043-f4ea-4d48-8d69-df63205915f7",
+                    "target": "9b1d4730-0e7e-4b7b-a952-df15d6ff16a5",
+                    "targetPort": "60f510b4-7e52-4cb9-9122-1fb33a52d16e",
                     "points": [
                         {
                             "id": "8aef8c89-01c2-47e4-a38c-bf93db977392",
                             "type": "point",
-                            "x": 665.337440113294,
-                            "y": 454.74998136646093
+                            "x": 665.4583040805701,
+                            "y": 538.4028211678692
                         },
                         {
                             "id": "a69ace13-2ce1-4f2e-aaa0-9786a51f5717",
                             "type": "point",
-                            "x": 753.7625168689444,
-                            "y": 345.212492506503
+                            "x": 784.9305008777334,
+                            "y": 343.708296494351
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "e94d9880-0ab7-4351-9ef1-210f46e489e9": {
+                    "id": "e94d9880-0ab7-4351-9ef1-210f46e489e9",
+                    "type": "triangle-link",
+                    "selected": false,
+                    "source": "20872e7f-cdaa-4367-a960-bf1a3ad22715",
+                    "sourcePort": "42efab46-4571-493f-a1f2-48c52c16bfdd",
+                    "target": "c3cd076d-d8d8-41f3-affd-9df5071e95a5",
+                    "targetPort": "429493c5-caf5-469e-a52a-f7ea1ad3f325",
+                    "points": [
+                        {
+                            "id": "2cd6aa5f-75ca-45d5-ab5c-b51b1e24b273",
+                            "type": "point",
+                            "x": 267.5972526970765,
+                            "y": 362.24997390598287
+                        },
+                        {
+                            "id": "6b123c4a-82d2-4ff0-96bf-a36dc058b981",
+                            "type": "point",
+                            "x": 318.3611155603145,
+                            "y": 303.8749855330675
                         }
                     ],
                     "labels": [],
@@ -210,7 +210,7 @@
             }
         },
         {
-            "id": "ef6e77c2-6703-44d2-9bbb-3d2e46d2bec5",
+            "id": "7fd183fe-13f0-4ab5-b1ac-d885d6030203",
             "type": "diagram-nodes",
             "isSvg": false,
             "transformed": true,
@@ -218,7 +218,7 @@
                 "7dfa4275-f8c3-4b0f-98e5-4a0bb64b2394": {
                     "id": "7dfa4275-f8c3-4b0f-98e5-4a0bb64b2394",
                     "type": "custom-node",
-                    "selected": true,
+                    "selected": false,
                     "extras": {
                         "type": "Start",
                         "borderColor": "rgb(0,192,255)"
@@ -230,8 +230,8 @@
                             "id": "f5e2e54a-d02c-4e90-b955-b0efc1ee5ac7",
                             "type": "default",
                             "extras": {},
-                            "x": 44.112515906120265,
-                            "y": 272.23197669918585,
+                            "x": 43.99998374442169,
+                            "y": 272.31944165464597,
                             "name": "out-0",
                             "alignment": "right",
                             "parentNode": "7dfa4275-f8c3-4b0f-98e5-4a0bb64b2394",
@@ -252,25 +252,266 @@
                         "f5e2e54a-d02c-4e90-b955-b0efc1ee5ac7"
                     ]
                 },
-                "9e89d907-197c-4462-8fc6-8b8ab3650f56": {
-                    "id": "9e89d907-197c-4462-8fc6-8b8ab3650f56",
+                "9b1d4730-0e7e-4b7b-a952-df15d6ff16a5": {
+                    "id": "9b1d4730-0e7e-4b7b-a952-df15d6ff16a5",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "library_component",
+                        "path": "xai_components/xai_gdrive/gdrive_components.py",
+                        "description": "A component that downloads a file from Google Drive.\n\n##### inPorts:\n- file_id: the ID of the file to download.\n- output_path: the path to save the downloaded file.",
+                        "lineNo": [
+                            {
+                                "lineno": 171,
+                                "end_lineno": 193
+                            }
+                        ]
+                    },
+                    "x": 773.6650200515213,
+                    "y": 241.0989101858943,
+                    "ports": [
+                        {
+                            "id": "48d530dd-f190-4ceb-9ef6-d5c027505496",
+                            "type": "default",
+                            "extras": {},
+                            "x": 774.5415817934589,
+                            "y": 267.98609195518213,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "9b1d4730-0e7e-4b7b-a952-df15d6ff16a5",
+                            "links": [
+                                "ce33f246-a77a-4bb1-9f20-b22f2307be8d"
+                            ],
+                            "in": true,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "6eb8ea17-d21d-4648-8aeb-aceae333ca16",
+                            "type": "default",
+                            "extras": {},
+                            "x": 774.5415817934589,
+                            "y": 289.76385236584287,
+                            "name": "parameter-any-gdrive",
+                            "alignment": "left",
+                            "parentNode": "9b1d4730-0e7e-4b7b-a952-df15d6ff16a5",
+                            "links": [
+                                "7bd42049-0589-4a35-81ee-375da1cda2d5"
+                            ],
+                            "in": true,
+                            "label": "gdrive",
+                            "varName": "gdrive",
+                            "portType": "",
+                            "dataType": "any"
+                        },
+                        {
+                            "id": "635f5911-a0b9-45af-9b6c-6191f91777c4",
+                            "type": "default",
+                            "extras": {},
+                            "x": 774.5415817934589,
+                            "y": 311.5416465598004,
+                            "name": "parameter-string-file_id",
+                            "alignment": "left",
+                            "parentNode": "9b1d4730-0e7e-4b7b-a952-df15d6ff16a5",
+                            "links": [
+                                "95870faf-aeec-4deb-8940-a2599a3431ec"
+                            ],
+                            "in": true,
+                            "label": "★file_id",
+                            "varName": "★file_id",
+                            "portType": "",
+                            "dataType": "string"
+                        },
+                        {
+                            "id": "60f510b4-7e52-4cb9-9122-1fb33a52d16e",
+                            "type": "default",
+                            "extras": {},
+                            "x": 774.5415817934589,
+                            "y": 333.3194069704612,
+                            "name": "parameter-string-output_path",
+                            "alignment": "left",
+                            "parentNode": "9b1d4730-0e7e-4b7b-a952-df15d6ff16a5",
+                            "links": [
+                                "cc2d3657-d7a4-4361-b259-30ceafd24f6b"
+                            ],
+                            "in": true,
+                            "label": "★output_path",
+                            "varName": "★output_path",
+                            "portType": "",
+                            "dataType": "string"
+                        },
+                        {
+                            "id": "f4e4647a-8794-4d32-90e3-57d1a30bc905",
+                            "type": "default",
+                            "extras": {},
+                            "x": 957.9583974069277,
+                            "y": 267.98609195518213,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "9b1d4730-0e7e-4b7b-a952-df15d6ff16a5",
+                            "links": [
+                                "8e3cd1fd-ffe6-4311-9461-4dc2bc1b6183"
+                            ],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        }
+                    ],
+                    "name": "DownloadFileFromGDrive",
+                    "color": "rgb(255,204,0)",
+                    "portsInOrder": [
+                        "48d530dd-f190-4ceb-9ef6-d5c027505496",
+                        "6eb8ea17-d21d-4648-8aeb-aceae333ca16",
+                        "635f5911-a0b9-45af-9b6c-6191f91777c4",
+                        "60f510b4-7e52-4cb9-9122-1fb33a52d16e"
+                    ],
+                    "portsOutOrder": [
+                        "f4e4647a-8794-4d32-90e3-57d1a30bc905"
+                    ]
+                },
+                "c3cd076d-d8d8-41f3-affd-9df5071e95a5": {
+                    "id": "c3cd076d-d8d8-41f3-affd-9df5071e95a5",
+                    "type": "custom-node",
+                    "selected": false,
+                    "extras": {
+                        "type": "library_component",
+                        "path": "xai_components/xai_gdrive/gdrive_components.py",
+                        "description": "A component that authenticates with Google Drive using a service account.\n\n##### inPorts:\n- json_path: the path to the service account's secrets JSON file.",
+                        "lineNo": [
+                            {
+                                "lineno": 18,
+                                "end_lineno": 64
+                            }
+                        ],
+                        "borderColor": "rgb(0,192,255)"
+                    },
+                    "x": 307.0939743663248,
+                    "y": 244.82992123110927,
+                    "ports": [
+                        {
+                            "id": "e30b8d6f-a278-4bca-9c5a-d9ee77e4ccce",
+                            "type": "default",
+                            "extras": {},
+                            "x": 307.97222603642473,
+                            "y": 271.708335598517,
+                            "name": "in-0",
+                            "alignment": "left",
+                            "parentNode": "c3cd076d-d8d8-41f3-affd-9df5071e95a5",
+                            "links": [
+                                "ef011720-f857-4023-9190-b624affd8e38"
+                            ],
+                            "in": true,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "429493c5-caf5-469e-a52a-f7ea1ad3f325",
+                            "type": "default",
+                            "extras": {},
+                            "x": 307.97222603642473,
+                            "y": 293.48609600917774,
+                            "name": "parameter-string-json_path",
+                            "alignment": "left",
+                            "parentNode": "c3cd076d-d8d8-41f3-affd-9df5071e95a5",
+                            "links": [
+                                "e94d9880-0ab7-4351-9ef1-210f46e489e9"
+                            ],
+                            "in": true,
+                            "label": "json_path",
+                            "varName": "json_path",
+                            "portType": "",
+                            "dataType": "string"
+                        },
+                        {
+                            "id": "fd5775f8-f0fb-4885-aaa4-c73a6cf3c14a",
+                            "type": "default",
+                            "extras": {},
+                            "x": 456.4166403511734,
+                            "y": 271.708335598517,
+                            "name": "out-0",
+                            "alignment": "right",
+                            "parentNode": "c3cd076d-d8d8-41f3-affd-9df5071e95a5",
+                            "links": [
+                                "ce33f246-a77a-4bb1-9f20-b22f2307be8d"
+                            ],
+                            "in": false,
+                            "label": "▶",
+                            "varName": "▶",
+                            "portType": "",
+                            "dataType": ""
+                        },
+                        {
+                            "id": "900f13bd-f988-428a-a3e7-ceb351d879a2",
+                            "type": "default",
+                            "extras": {},
+                            "x": 456.4166403511734,
+                            "y": 293.48609600917774,
+                            "name": "parameter-out-any-gauth",
+                            "alignment": "right",
+                            "parentNode": "c3cd076d-d8d8-41f3-affd-9df5071e95a5",
+                            "links": [],
+                            "in": false,
+                            "label": "gauth",
+                            "varName": "gauth",
+                            "portType": "",
+                            "dataType": "any"
+                        },
+                        {
+                            "id": "1d0d953d-5a63-4110-a438-4e48f5d9be01",
+                            "type": "default",
+                            "extras": {},
+                            "x": 456.4166403511734,
+                            "y": 315.2638902031353,
+                            "name": "parameter-out-any-gdrive",
+                            "alignment": "right",
+                            "parentNode": "c3cd076d-d8d8-41f3-affd-9df5071e95a5",
+                            "links": [
+                                "7bd42049-0589-4a35-81ee-375da1cda2d5"
+                            ],
+                            "in": false,
+                            "label": "gdrive",
+                            "varName": "gdrive",
+                            "portType": "",
+                            "dataType": "any"
+                        }
+                    ],
+                    "name": "GDriveServiceAuth",
+                    "color": "rgb(15,255,255)",
+                    "portsInOrder": [
+                        "e30b8d6f-a278-4bca-9c5a-d9ee77e4ccce",
+                        "429493c5-caf5-469e-a52a-f7ea1ad3f325"
+                    ],
+                    "portsOutOrder": [
+                        "fd5775f8-f0fb-4885-aaa4-c73a6cf3c14a",
+                        "900f13bd-f988-428a-a3e7-ceb351d879a2",
+                        "1d0d953d-5a63-4110-a438-4e48f5d9be01"
+                    ]
+                },
+                "9da6d81a-307d-46d8-8bbd-95540a1b16bc": {
+                    "id": "9da6d81a-307d-46d8-8bbd-95540a1b16bc",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
                         "type": "Finish"
                     },
-                    "x": 987.0536826568266,
-                    "y": 242.88517530239767,
+                    "x": 1066.758479704797,
+                    "y": 246.20620851272977,
                     "ports": [
                         {
-                            "id": "a5f75c51-418d-480b-8f9b-30fbe7d78f24",
+                            "id": "f3011191-b5f9-4dd3-aec2-bbfa77207d51",
                             "type": "default",
                             "extras": {},
-                            "x": 987.8499259975065,
-                            "y": 269.67498652967475,
+                            "x": 1067.6389785877395,
+                            "y": 273.08331577898286,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "9e89d907-197c-4462-8fc6-8b8ab3650f56",
+                            "parentNode": "9da6d81a-307d-46d8-8bbd-95540a1b16bc",
                             "links": [
                                 "8e3cd1fd-ffe6-4311-9461-4dc2bc1b6183"
                             ],
@@ -281,14 +522,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "b0eb0f5e-10ba-4bee-887f-48dc3368e3a4",
+                            "id": "e2e39f46-b21f-4b65-9bdb-fc4d6a9ba86e",
                             "type": "default",
                             "extras": {},
-                            "x": 987.8499259975065,
-                            "y": 291.2749792324826,
+                            "x": 1067.6389785877395,
+                            "y": 294.8610761896436,
                             "name": "parameter-dynalist-outputs",
                             "alignment": "left",
-                            "parentNode": "9e89d907-197c-4462-8fc6-8b8ab3650f56",
+                            "parentNode": "9da6d81a-307d-46d8-8bbd-95540a1b16bc",
                             "links": [],
                             "in": true,
                             "label": "outputs",
@@ -305,272 +546,30 @@
                     "name": "Finish",
                     "color": "rgb(255,102,102)",
                     "portsInOrder": [
-                        "a5f75c51-418d-480b-8f9b-30fbe7d78f24",
-                        "b0eb0f5e-10ba-4bee-887f-48dc3368e3a4"
+                        "f3011191-b5f9-4dd3-aec2-bbfa77207d51",
+                        "e2e39f46-b21f-4b65-9bdb-fc4d6a9ba86e"
                     ],
                     "portsOutOrder": []
                 },
-                "192239b1-184c-4107-a978-b7303dcb23e9": {
-                    "id": "192239b1-184c-4107-a978-b7303dcb23e9",
-                    "type": "custom-node",
-                    "selected": false,
-                    "extras": {
-                        "type": "library_component",
-                        "path": "xai_components/xai_gdrive/gdrive_components.py",
-                        "description": "A component that downloads a file from Google Drive.\n\n##### inPorts:\n- file_id: the ID of the file to download.\n- output_path: the path to save the downloaded file.",
-                        "lineNo": [
-                            {
-                                "lineno": 165,
-                                "end_lineno": 187
-                            }
-                        ],
-                        "nextNode": "None"
-                    },
-                    "x": 742.6687100884217,
-                    "y": 243.3129323261157,
-                    "ports": [
-                        {
-                            "id": "b801fdd0-3795-497b-8776-db00e607728f",
-                            "type": "default",
-                            "extras": {},
-                            "x": 743.4625027531569,
-                            "y": 270.1124802234594,
-                            "name": "in-0",
-                            "alignment": "left",
-                            "parentNode": "192239b1-184c-4107-a978-b7303dcb23e9",
-                            "links": [
-                                "ce33f246-a77a-4bb1-9f20-b22f2307be8d"
-                            ],
-                            "in": true,
-                            "label": "▶",
-                            "varName": "▶",
-                            "portType": "",
-                            "dataType": ""
-                        },
-                        {
-                            "id": "c157120a-0189-440b-a19f-29a443ebf671",
-                            "type": "default",
-                            "extras": {},
-                            "x": 743.4625027531569,
-                            "y": 291.712506709564,
-                            "name": "parameter-any-gdrive",
-                            "alignment": "left",
-                            "parentNode": "192239b1-184c-4107-a978-b7303dcb23e9",
-                            "links": [
-                                "7bd42049-0589-4a35-81ee-375da1cda2d5"
-                            ],
-                            "in": true,
-                            "label": "gdrive",
-                            "varName": "gdrive",
-                            "portType": "",
-                            "dataType": "any"
-                        },
-                        {
-                            "id": "4ad28ca3-ae00-4374-b691-3708da9e40e2",
-                            "type": "default",
-                            "extras": {},
-                            "x": 743.4625027531569,
-                            "y": 313.3124656290751,
-                            "name": "parameter-string-file_id",
-                            "alignment": "left",
-                            "parentNode": "192239b1-184c-4107-a978-b7303dcb23e9",
-                            "links": [
-                                "95870faf-aeec-4deb-8940-a2599a3431ec"
-                            ],
-                            "in": true,
-                            "label": "★file_id",
-                            "varName": "★file_id",
-                            "portType": "",
-                            "dataType": "string"
-                        },
-                        {
-                            "id": "471d79fb-e33e-4248-83cd-24bf35ee9785",
-                            "type": "default",
-                            "extras": {},
-                            "x": 743.4625027531569,
-                            "y": 334.9124921151798,
-                            "name": "parameter-string-output_path",
-                            "alignment": "left",
-                            "parentNode": "192239b1-184c-4107-a978-b7303dcb23e9",
-                            "links": [
-                                "cc2d3657-d7a4-4361-b259-30ceafd24f6b"
-                            ],
-                            "in": true,
-                            "label": "★output_path",
-                            "varName": "★output_path",
-                            "portType": "",
-                            "dataType": "string"
-                        },
-                        {
-                            "id": "09f11514-0df2-4e25-81d1-6e1dc03fed10",
-                            "type": "default",
-                            "extras": {},
-                            "x": 927.1999894200158,
-                            "y": 270.1124802234594,
-                            "name": "out-0",
-                            "alignment": "right",
-                            "parentNode": "192239b1-184c-4107-a978-b7303dcb23e9",
-                            "links": [
-                                "8e3cd1fd-ffe6-4311-9461-4dc2bc1b6183"
-                            ],
-                            "in": false,
-                            "label": "▶",
-                            "varName": "▶",
-                            "portType": "",
-                            "dataType": ""
-                        }
-                    ],
-                    "name": "DownloadFileFromGDrive",
-                    "color": "rgb(255,102,102)",
-                    "portsInOrder": [
-                        "b801fdd0-3795-497b-8776-db00e607728f",
-                        "c157120a-0189-440b-a19f-29a443ebf671",
-                        "4ad28ca3-ae00-4374-b691-3708da9e40e2",
-                        "471d79fb-e33e-4248-83cd-24bf35ee9785"
-                    ],
-                    "portsOutOrder": [
-                        "09f11514-0df2-4e25-81d1-6e1dc03fed10"
-                    ]
-                },
-                "5911eff8-f9e4-4065-9b70-e018f087a362": {
-                    "id": "5911eff8-f9e4-4065-9b70-e018f087a362",
-                    "type": "custom-node",
-                    "selected": false,
-                    "extras": {
-                        "type": "library_component",
-                        "path": "xai_components/xai_gdrive/gdrive_components.py",
-                        "description": "A component that authenticates with Google Drive using a service account.\n\n##### inPorts:\n- json_path: the path to the service account's secrets JSON file.",
-                        "lineNo": [
-                            {
-                                "lineno": 25,
-                                "end_lineno": 57
-                            }
-                        ],
-                        "borderColor": "rgb(0,192,255)"
-                    },
-                    "x": 307.0939743663248,
-                    "y": 244.82992123110927,
-                    "ports": [
-                        {
-                            "id": "6e9ae455-fc97-44ad-b3df-bcacd9418aa9",
-                            "type": "default",
-                            "extras": {},
-                            "x": 307.8874975280068,
-                            "y": 271.62499220526865,
-                            "name": "in-0",
-                            "alignment": "left",
-                            "parentNode": "5911eff8-f9e4-4065-9b70-e018f087a362",
-                            "links": [
-                                "ef011720-f857-4023-9190-b624affd8e38"
-                            ],
-                            "in": true,
-                            "label": "▶",
-                            "varName": "▶",
-                            "portType": "",
-                            "dataType": ""
-                        },
-                        {
-                            "id": "946c5cc0-c7e4-460f-a501-912d8e3989f8",
-                            "type": "default",
-                            "extras": {},
-                            "x": 307.8874975280068,
-                            "y": 293.2249849080765,
-                            "name": "parameter-string-service_json_path",
-                            "alignment": "left",
-                            "parentNode": "5911eff8-f9e4-4065-9b70-e018f087a362",
-                            "links": [
-                                "38bb5b47-9a41-4f30-a005-918727db3d8c"
-                            ],
-                            "in": true,
-                            "label": "★service_json_path",
-                            "varName": "★service_json_path",
-                            "portType": "",
-                            "dataType": "string"
-                        },
-                        {
-                            "id": "0ade9252-8b85-44d7-80a2-b0699b8f0ce1",
-                            "type": "default",
-                            "extras": {},
-                            "x": 485.92499878924997,
-                            "y": 271.62499220526865,
-                            "name": "out-0",
-                            "alignment": "right",
-                            "parentNode": "5911eff8-f9e4-4065-9b70-e018f087a362",
-                            "links": [
-                                "ce33f246-a77a-4bb1-9f20-b22f2307be8d"
-                            ],
-                            "in": false,
-                            "label": "▶",
-                            "varName": "▶",
-                            "portType": "",
-                            "dataType": ""
-                        },
-                        {
-                            "id": "1d74e683-e462-4f8c-ac9f-a5806ecd1c00",
-                            "type": "default",
-                            "extras": {},
-                            "x": 485.92499878924997,
-                            "y": 293.2249849080765,
-                            "name": "parameter-out-any-gauth",
-                            "alignment": "right",
-                            "parentNode": "5911eff8-f9e4-4065-9b70-e018f087a362",
-                            "links": [],
-                            "in": false,
-                            "label": "gauth",
-                            "varName": "gauth",
-                            "portType": "",
-                            "dataType": "any"
-                        },
-                        {
-                            "id": "01b3be47-9f77-440a-a145-587dddc08733",
-                            "type": "default",
-                            "extras": {},
-                            "x": 485.92499878924997,
-                            "y": 314.8250113941812,
-                            "name": "parameter-out-any-gdrive",
-                            "alignment": "right",
-                            "parentNode": "5911eff8-f9e4-4065-9b70-e018f087a362",
-                            "links": [
-                                "7bd42049-0589-4a35-81ee-375da1cda2d5"
-                            ],
-                            "in": false,
-                            "label": "gdrive",
-                            "varName": "gdrive",
-                            "portType": "",
-                            "dataType": "any"
-                        }
-                    ],
-                    "name": "GDriveServiceAuth",
-                    "color": "rgb(51,51,51)",
-                    "portsInOrder": [
-                        "6e9ae455-fc97-44ad-b3df-bcacd9418aa9",
-                        "946c5cc0-c7e4-460f-a501-912d8e3989f8"
-                    ],
-                    "portsOutOrder": [
-                        "0ade9252-8b85-44d7-80a2-b0699b8f0ce1",
-                        "1d74e683-e462-4f8c-ac9f-a5806ecd1c00",
-                        "01b3be47-9f77-440a-a145-587dddc08733"
-                    ]
-                },
-                "4ae287b2-9955-4d15-a8ed-be66d362f421": {
-                    "id": "4ae287b2-9955-4d15-a8ed-be66d362f421",
+                "702b8953-46a3-4476-b865-68c70c5ac06d": {
+                    "id": "702b8953-46a3-4476-b865-68c70c5ac06d",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
                         "type": "string"
                     },
-                    "x": 546.3545745194962,
-                    "y": 341.7080107667216,
+                    "x": 550.782618799939,
+                    "y": 413.6637303239172,
                     "ports": [
                         {
-                            "id": "ea53b171-3185-409f-b428-a076764a5e3c",
+                            "id": "ce3aec9b-4ee1-4daa-8e61-cb5e1cfc299d",
                             "type": "default",
                             "extras": {},
-                            "x": 666.7750946437242,
-                            "y": 365.4999904034928,
+                            "x": 670.97212874053,
+                            "y": 437.98607393742384,
                             "name": "parameter-out-0",
                             "alignment": "right",
-                            "parentNode": "4ae287b2-9955-4d15-a8ed-be66d362f421",
+                            "parentNode": "702b8953-46a3-4476-b865-68c70c5ac06d",
                             "links": [
                                 "95870faf-aeec-4deb-8940-a2599a3431ec"
                             ],
@@ -585,11 +584,11 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "ea53b171-3185-409f-b428-a076764a5e3c"
+                        "ce3aec9b-4ee1-4daa-8e61-cb5e1cfc299d"
                     ]
                 },
-                "3a32b75c-5419-4628-9791-41898a373e21": {
-                    "id": "3a32b75c-5419-4628-9791-41898a373e21",
+                "20872e7f-cdaa-4367-a960-bf1a3ad22715": {
+                    "id": "20872e7f-cdaa-4367-a960-bf1a3ad22715",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -600,16 +599,16 @@
                     "y": 327.52821187995295,
                     "ports": [
                         {
-                            "id": "48db060f-ac44-4b82-9a24-eadb21aca214",
+                            "id": "42efab46-4571-493f-a1f2-48c52c16bfdd",
                             "type": "default",
                             "extras": {},
-                            "x": 257.49998059131406,
-                            "y": 351.32499202509103,
+                            "x": 257.20836317318674,
+                            "y": 351.8610991622855,
                             "name": "parameter-out-0",
                             "alignment": "right",
-                            "parentNode": "3a32b75c-5419-4628-9791-41898a373e21",
+                            "parentNode": "20872e7f-cdaa-4367-a960-bf1a3ad22715",
                             "links": [
-                                "38bb5b47-9a41-4f30-a005-918727db3d8c"
+                                "e94d9880-0ab7-4351-9ef1-210f46e489e9"
                             ],
                             "in": false,
                             "label": "▶",
@@ -622,11 +621,11 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "48db060f-ac44-4b82-9a24-eadb21aca214"
+                        "42efab46-4571-493f-a1f2-48c52c16bfdd"
                     ]
                 },
-                "a9e76731-5270-4184-8a1c-3537ffcc84cb": {
-                    "id": "a9e76731-5270-4184-8a1c-3537ffcc84cb",
+                "29213b77-183f-4829-84e1-322099fe8c6f": {
+                    "id": "29213b77-183f-4829-84e1-322099fe8c6f",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -634,17 +633,17 @@
                         "attached": false
                     },
                     "x": 581.0334600013924,
-                    "y": 420.6580404511592,
+                    "y": 503.6838707094618,
                     "ports": [
                         {
-                            "id": "bc0c2e3d-3f9d-4f90-bfff-30666f985169",
+                            "id": "74612043-f4ea-4d48-8d69-df63205915f7",
                             "type": "default",
                             "extras": {},
-                            "x": 655.0374259975065,
-                            "y": 444.4499672506734,
+                            "x": 655.0693849962956,
+                            "y": 528.0139316439795,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "a9e76731-5270-4184-8a1c-3537ffcc84cb",
+                            "parentNode": "29213b77-183f-4829-84e1-322099fe8c6f",
                             "links": [
                                 "cc2d3657-d7a4-4361-b259-30ceafd24f6b"
                             ],
@@ -659,7 +658,7 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "bc0c2e3d-3f9d-4f90-bfff-30666f985169"
+                        "74612043-f4ea-4d48-8d69-df63205915f7"
                     ]
                 }
             }

--- a/examples/GDriveSimpleUpdate.xircuits
+++ b/examples/GDriveSimpleUpdate.xircuits
@@ -6,7 +6,7 @@
     "gridSize": 0,
     "layers": [
         {
-            "id": "154c0a82-ca45-43b3-a431-621d7b893539",
+            "id": "f5b19187-f02a-4477-bcc4-0b0fa17fbc73",
             "type": "diagram-links",
             "isSvg": true,
             "transformed": true,
@@ -17,48 +17,20 @@
                     "selected": false,
                     "source": "e705a570-8daf-4330-8c6b-9d8fceda6bd7",
                     "sourcePort": "1b8ccda9-ffba-4b17-8d65-652de327b62d",
-                    "target": "b39b7008-08ab-46df-b03b-a7a50949a66e",
-                    "targetPort": "d137dfc5-6e85-48bc-9ddc-599d7c4d0d5f",
+                    "target": "f7f36402-79f8-4554-9bc2-f5db7ad9c2bb",
+                    "targetPort": "ba13fa34-f79c-40fd-bebc-04bed17ebe7a",
                     "points": [
                         {
                             "id": "cda35395-1baf-4a71-a98b-2df219d99447",
                             "type": "point",
-                            "x": 194.91250441564932,
-                            "y": -29.312503581085153
+                            "x": 194.88889827724,
+                            "y": -29.124987818468153
                         },
                         {
                             "id": "f04339b9-3ce7-447e-8fe6-737323970cff",
                             "type": "point",
-                            "x": 433.26248230480024,
-                            "y": -30.67498100959341
-                        }
-                    ],
-                    "labels": [],
-                    "width": 3,
-                    "color": "gray",
-                    "curvyness": 50,
-                    "selectedColor": "rgb(0,192,255)"
-                },
-                "3479534e-4629-457e-b1c4-2c040d4a24c4": {
-                    "id": "3479534e-4629-457e-b1c4-2c040d4a24c4",
-                    "type": "triangle-link",
-                    "selected": false,
-                    "source": "80f8d8e6-ca6b-402c-94d5-cdf1f245abe8",
-                    "sourcePort": "2cc9daca-4561-4010-acb7-69276e6c8fc3",
-                    "target": "b39b7008-08ab-46df-b03b-a7a50949a66e",
-                    "targetPort": "8f86266e-fcd3-4f64-a1e6-43b71dc50d21",
-                    "points": [
-                        {
-                            "id": "ccb4d7b8-6954-4041-8e39-b8e148db4a07",
-                            "type": "point",
-                            "x": 380.2124749345172,
-                            "y": 41.025009316910115
-                        },
-                        {
-                            "id": "acb18565-8fd6-4a80-8340-5c620e907903",
-                            "type": "point",
-                            "x": 433.26248230480024,
-                            "y": -9.074996210802139
+                            "x": 433.44442177174454,
+                            "y": -30.49999004970618
                         }
                     ],
                     "labels": [],
@@ -71,22 +43,22 @@
                     "id": "e5786443-a9f7-4224-96ad-e983ab1f754d",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "b39b7008-08ab-46df-b03b-a7a50949a66e",
-                    "sourcePort": "50599ac3-4f0f-48d4-9b6e-040b64ddd0aa",
-                    "target": "4815caf2-b1b8-454d-8ae0-cca354d4a1a0",
-                    "targetPort": "802f239c-41ed-4eff-a745-5bca6daac34c",
+                    "source": "f7f36402-79f8-4554-9bc2-f5db7ad9c2bb",
+                    "sourcePort": "d7ea6d63-643f-4930-90d2-002d166f9687",
+                    "target": "270d3f0e-6169-4508-85e3-013e2f8526b6",
+                    "targetPort": "eaf67686-ad85-429a-92da-a21080722b8f",
                     "points": [
                         {
                             "id": "548e8cb7-be53-438f-9e1f-7f9cc3b4ffca",
                             "type": "point",
-                            "x": 611.3000472842095,
-                            "y": -30.67498100959341
+                            "x": 581.8888857535169,
+                            "y": -30.49999004970618
                         },
                         {
                             "id": "0d53942d-540e-4008-8230-b612ad2192ad",
                             "type": "point",
-                            "x": 1001.5750099433616,
-                            "y": -31.812480548950724
+                            "x": 1001.7500095402992,
+                            "y": -31.638871517129527
                         }
                     ],
                     "labels": [],
@@ -99,22 +71,22 @@
                     "id": "66bb697d-60e9-4a90-92f3-9ab2d7ccace5",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "b39b7008-08ab-46df-b03b-a7a50949a66e",
-                    "sourcePort": "ac0fb132-5dd0-44a5-9cd7-e7688a18d46d",
-                    "target": "4815caf2-b1b8-454d-8ae0-cca354d4a1a0",
-                    "targetPort": "19f01186-d053-4063-8942-4b5850466a14",
+                    "source": "f7f36402-79f8-4554-9bc2-f5db7ad9c2bb",
+                    "sourcePort": "b4211560-5012-4fb1-b067-b88ed756f997",
+                    "target": "270d3f0e-6169-4508-85e3-013e2f8526b6",
+                    "targetPort": "019b32b8-e90e-4bf0-be90-4c79ff86da06",
                     "points": [
                         {
                             "id": "81d8449b-c0a7-4c3c-945a-de42c396debd",
                             "type": "point",
-                            "x": 611.3000472842095,
-                            "y": 12.525002623196052
+                            "x": 581.8888857535169,
+                            "y": 13.055584187469526
                         },
                         {
                             "id": "2e8c9b0f-d0ce-4232-a728-52270ffea811",
                             "type": "point",
-                            "x": 1001.5750099433616,
-                            "y": -10.212481714952533
+                            "x": 1001.7500095402992,
+                            "y": -9.861101672642501
                         }
                     ],
                     "labels": [],
@@ -127,22 +99,22 @@
                     "id": "722604af-f81b-4413-9f04-10e2474bc3a6",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "8a0d9264-7419-4980-85bc-6e6556b93d98",
-                    "sourcePort": "84a24d7c-5f1c-4fce-9bad-4be264b4cd19",
-                    "target": "4815caf2-b1b8-454d-8ae0-cca354d4a1a0",
-                    "targetPort": "17060cc9-701a-4140-9617-bb24a2682a94",
+                    "source": "fb1b90f9-fe23-4653-a0df-983e61f01e78",
+                    "sourcePort": "f74eb53c-5f6d-4ff2-bd73-0661073f5c54",
+                    "target": "270d3f0e-6169-4508-85e3-013e2f8526b6",
+                    "targetPort": "7cb6b982-6c96-4241-8c4f-b53754b074a7",
                     "points": [
                         {
                             "id": "bc5e5912-bfd1-4738-9a31-1ac25ed3bb4a",
                             "type": "point",
-                            "x": 893.1999270276776,
-                            "y": 163.28748791142016
+                            "x": 893.0416671140711,
+                            "y": 163.91668191914977
                         },
                         {
                             "id": "289e18f5-2f5e-499d-84af-e50462ad92a2",
                             "type": "point",
-                            "x": 1001.5750099433616,
-                            "y": 32.98752243083166
+                            "x": 1001.7500095402992,
+                            "y": 33.69443801633155
                         }
                     ],
                     "labels": [],
@@ -155,22 +127,22 @@
                     "id": "87fcaf42-5686-4b97-af9c-228a4550ba15",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "4815caf2-b1b8-454d-8ae0-cca354d4a1a0",
-                    "sourcePort": "a2945246-af38-41a7-8c03-7cdb7a70b481",
-                    "target": "198936e3-96f0-43e1-938a-36ea9e9ee516",
-                    "targetPort": "b1605d41-c570-4371-8ec3-de508eeab887",
+                    "source": "270d3f0e-6169-4508-85e3-013e2f8526b6",
+                    "sourcePort": "e0dc188d-d5b5-4202-a187-eefd949c7640",
+                    "target": "48ff9f23-c64f-4238-8fa7-d860592fdf50",
+                    "targetPort": "de027635-480c-46f4-9e1a-59931de9d4d5",
                     "points": [
                         {
                             "id": "b2f8cf1b-8b6f-47e2-a3ff-004c8a091875",
                             "type": "point",
-                            "x": 1153.7750394244936,
-                            "y": -31.812480548950724
+                            "x": 1153.666667114071,
+                            "y": -31.638871517129527
                         },
                         {
                             "id": "ec6f881b-c6e3-4a41-a4c5-c826f3484656",
                             "type": "point",
-                            "x": 1256.8874638790926,
-                            "y": -31.749982852164166
+                            "x": 1257.0694346553446,
+                            "y": -31.569414516972905
                         }
                     ],
                     "labels": [],
@@ -183,22 +155,22 @@
                     "id": "93edb9d4-0cc7-4323-bf1b-2ce8411cb60a",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "c9dfe981-82af-4ea9-976b-67e57b1993dc",
-                    "sourcePort": "f84fb78b-6a20-4ee1-ac67-3d599ae2f228",
-                    "target": "4815caf2-b1b8-454d-8ae0-cca354d4a1a0",
-                    "targetPort": "1a3d933b-c007-44a0-9510-218625810d05",
+                    "source": "ea4f1050-3013-41ae-bacb-36bdc81bfc03",
+                    "sourcePort": "d763e803-b420-440f-8c59-e70750888b39",
+                    "target": "270d3f0e-6169-4508-85e3-013e2f8526b6",
+                    "targetPort": "e4447050-086c-470d-b0ca-c41bd6b7ad0a",
                     "points": [
                         {
                             "id": "04cf17b2-250e-466a-b220-ea5c01c3f909",
                             "type": "point",
-                            "x": 896.7374555875243,
-                            "y": 83.06251506054863
+                            "x": 896.6110491158399,
+                            "y": 83.69447940219811
                         },
                         {
                             "id": "c7578363-e812-4a2b-a172-1fd230b3642b",
                             "type": "point",
-                            "x": 1001.5750099433616,
-                            "y": 11.38750308383874
+                            "x": 1001.7500095402992,
+                            "y": 11.916668171844526
                         }
                     ],
                     "labels": [],
@@ -210,23 +182,51 @@
                 "de54daa8-e2ca-432c-b720-4cf27c85a7cf": {
                     "id": "de54daa8-e2ca-432c-b720-4cf27c85a7cf",
                     "type": "parameter-link",
-                    "selected": true,
-                    "source": "b1742226-af28-4c68-840a-c384bb5f3b5a",
-                    "sourcePort": "56f24bff-dd06-44c7-b28f-e3c1fb83a745",
-                    "target": "4815caf2-b1b8-454d-8ae0-cca354d4a1a0",
-                    "targetPort": "9d722fde-8c3e-4645-bc52-07e458d48431",
+                    "selected": false,
+                    "source": "cae51895-900e-499e-bb1b-642450e782cb",
+                    "sourcePort": "4ac67426-c2bc-48e2-b29d-13ac6ba8ff08",
+                    "target": "270d3f0e-6169-4508-85e3-013e2f8526b6",
+                    "targetPort": "c025a969-58b8-42c6-a6c9-e397d5909e15",
                     "points": [
                         {
                             "id": "661a7c99-4670-4194-a2b2-a6a2b4fd5b0d",
                             "type": "point",
-                            "x": 900.7750348180667,
-                            "y": 252.32496853563708
+                            "x": 900.9027649177269,
+                            "y": 252.94445773759662
                         },
                         {
                             "id": "4590036a-e3e7-451a-ae9b-451062b752d1",
                             "type": "point",
-                            "x": 1001.5750099433616,
-                            "y": 54.58752774261767
+                            "x": 1001.7500095402992,
+                            "y": 55.4722262145507
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "c45c007c-9f3d-48f5-8d27-3e569fdf0830": {
+                    "id": "c45c007c-9f3d-48f5-8d27-3e569fdf0830",
+                    "type": "triangle-link",
+                    "selected": true,
+                    "source": "ecedd470-2899-46cb-85f5-7cead6486e19",
+                    "sourcePort": "a0183f06-db9e-4dfd-9d52-311f3b46e18e",
+                    "target": "f7f36402-79f8-4554-9bc2-f5db7ad9c2bb",
+                    "targetPort": "4a167000-ee2b-4df8-a961-bd6eaa0ed2b7",
+                    "points": [
+                        {
+                            "id": "91fd73cf-9600-4c01-9576-689c7eb029e7",
+                            "type": "point",
+                            "x": 380.01393181778576,
+                            "y": 41.65278900763462
+                        },
+                        {
+                            "id": "03e820e3-208d-46cd-8044-d9e5e2c0c8e9",
+                            "type": "point",
+                            "x": 433.44442177174454,
+                            "y": -8.722220205219152
                         }
                     ],
                     "labels": [],
@@ -238,7 +238,7 @@
             }
         },
         {
-            "id": "1806317f-c73d-483c-a7eb-300da2629961",
+            "id": "066e69db-d3a4-4ced-92b9-2329cb5ed6f5",
             "type": "diagram-nodes",
             "isSvg": false,
             "transformed": true,
@@ -258,8 +258,8 @@
                             "id": "1b8ccda9-ffba-4b17-8d65-652de327b62d",
                             "type": "default",
                             "extras": {},
-                            "x": 184.61249682944003,
-                            "y": -39.61249713208751,
+                            "x": 184.50000788486457,
+                            "y": -39.51386201637407,
                             "name": "out-0",
                             "alignment": "right",
                             "parentNode": "e705a570-8daf-4330-8c6b-9d8fceda6bd7",
@@ -280,8 +280,8 @@
                         "1b8ccda9-ffba-4b17-8d65-652de327b62d"
                     ]
                 },
-                "198936e3-96f0-43e1-938a-36ea9e9ee516": {
-                    "id": "198936e3-96f0-43e1-938a-36ea9e9ee516",
+                "48ff9f23-c64f-4238-8fa7-d860592fdf50": {
+                    "id": "48ff9f23-c64f-4238-8fa7-d860592fdf50",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -291,14 +291,14 @@
                     "y": -68.85158490566037,
                     "ports": [
                         {
-                            "id": "b1605d41-c570-4371-8ec3-de508eeab887",
+                            "id": "de027635-480c-46f4-9e1a-59931de9d4d5",
                             "type": "default",
                             "extras": {},
-                            "x": 1246.5874562928834,
-                            "y": -42.049976403166525,
+                            "x": 1246.680529148131,
+                            "y": -41.95832002418657,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "198936e3-96f0-43e1-938a-36ea9e9ee516",
+                            "parentNode": "48ff9f23-c64f-4238-8fa7-d860592fdf50",
                             "links": [
                                 "87fcaf42-5686-4b97-af9c-228a4550ba15"
                             ],
@@ -309,14 +309,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "06d62dad-84cf-4bac-abe0-8c6c5d24aeac",
+                            "id": "bd73985b-52d7-4553-9988-7156c09bbb23",
                             "type": "default",
                             "extras": {},
-                            "x": 1246.5874562928834,
-                            "y": -20.449991604375253,
+                            "x": 1246.680529148131,
+                            "y": -20.180550179699544,
                             "name": "parameter-dynalist-outputs",
                             "alignment": "left",
-                            "parentNode": "198936e3-96f0-43e1-938a-36ea9e9ee516",
+                            "parentNode": "48ff9f23-c64f-4238-8fa7-d860592fdf50",
                             "links": [],
                             "in": true,
                             "label": "outputs",
@@ -333,13 +333,13 @@
                     "name": "Finish",
                     "color": "rgb(255,102,102)",
                     "portsInOrder": [
-                        "b1605d41-c570-4371-8ec3-de508eeab887",
-                        "06d62dad-84cf-4bac-abe0-8c6c5d24aeac"
+                        "de027635-480c-46f4-9e1a-59931de9d4d5",
+                        "bd73985b-52d7-4553-9988-7156c09bbb23"
                     ],
                     "portsOutOrder": []
                 },
-                "b39b7008-08ab-46df-b03b-a7a50949a66e": {
-                    "id": "b39b7008-08ab-46df-b03b-a7a50949a66e",
+                "f7f36402-79f8-4554-9bc2-f5db7ad9c2bb": {
+                    "id": "f7f36402-79f8-4554-9bc2-f5db7ad9c2bb",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -348,23 +348,24 @@
                         "description": "A component that authenticates with Google Drive using a service account.\n\n##### inPorts:\n- json_path: the path to the service account's secrets JSON file.",
                         "lineNo": [
                             {
-                                "lineno": 25,
-                                "end_lineno": 57
+                                "lineno": 18,
+                                "end_lineno": 64
                             }
-                        ]
+                        ],
+                        "borderColor": "rgb(0,192,255)"
                     },
                     "x": 422.17349743748844,
                     "y": -67.78583006619719,
                     "ports": [
                         {
-                            "id": "d137dfc5-6e85-48bc-9ddc-599d7c4d0d5f",
+                            "id": "ba13fa34-f79c-40fd-bebc-04bed17ebe7a",
                             "type": "default",
                             "extras": {},
-                            "x": 422.96247471859095,
-                            "y": -40.97497456059577,
+                            "x": 423.0555475738386,
+                            "y": -40.88888044208162,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "b39b7008-08ab-46df-b03b-a7a50949a66e",
+                            "parentNode": "f7f36402-79f8-4554-9bc2-f5db7ad9c2bb",
                             "links": [
                                 "a617ca34-5835-422e-ab32-361f84f4fc6d"
                             ],
@@ -375,32 +376,32 @@
                             "dataType": ""
                         },
                         {
-                            "id": "8f86266e-fcd3-4f64-a1e6-43b71dc50d21",
+                            "id": "4a167000-ee2b-4df8-a961-bd6eaa0ed2b7",
                             "type": "default",
                             "extras": {},
-                            "x": 422.96247471859095,
-                            "y": -19.374989761804496,
-                            "name": "parameter-string-service_json_path",
+                            "x": 423.0555475738386,
+                            "y": -19.111110597594593,
+                            "name": "parameter-string-json_path",
                             "alignment": "left",
-                            "parentNode": "b39b7008-08ab-46df-b03b-a7a50949a66e",
+                            "parentNode": "f7f36402-79f8-4554-9bc2-f5db7ad9c2bb",
                             "links": [
-                                "3479534e-4629-457e-b1c4-2c040d4a24c4"
+                                "c45c007c-9f3d-48f5-8d27-3e569fdf0830"
                             ],
                             "in": true,
-                            "label": "★service_json_path",
-                            "varName": "★service_json_path",
+                            "label": "json_path",
+                            "varName": "json_path",
                             "portType": "",
                             "dataType": "string"
                         },
                         {
-                            "id": "50599ac3-4f0f-48d4-9b6e-040b64ddd0aa",
+                            "id": "d7ea6d63-643f-4930-90d2-002d166f9687",
                             "type": "default",
                             "extras": {},
-                            "x": 601.0000677684142,
-                            "y": -40.97497456059577,
+                            "x": 571.4999802463032,
+                            "y": -40.88888044208162,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "b39b7008-08ab-46df-b03b-a7a50949a66e",
+                            "parentNode": "f7f36402-79f8-4554-9bc2-f5db7ad9c2bb",
                             "links": [
                                 "e5786443-a9f7-4224-96ad-e983ab1f754d"
                             ],
@@ -411,14 +412,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "5a02ac7b-8376-42d8-be3e-0e59d73f6738",
+                            "id": "a36d9bee-1041-4c06-9497-4aff5ab2da93",
                             "type": "default",
                             "extras": {},
-                            "x": 601.0000677684142,
-                            "y": -19.374989761804496,
+                            "x": 571.4999802463032,
+                            "y": -19.111110597594593,
                             "name": "parameter-out-any-gauth",
                             "alignment": "right",
-                            "parentNode": "b39b7008-08ab-46df-b03b-a7a50949a66e",
+                            "parentNode": "f7f36402-79f8-4554-9bc2-f5db7ad9c2bb",
                             "links": [],
                             "in": false,
                             "label": "gauth",
@@ -427,14 +428,14 @@
                             "dataType": "any"
                         },
                         {
-                            "id": "ac0fb132-5dd0-44a5-9cd7-e7688a18d46d",
+                            "id": "b4211560-5012-4fb1-b067-b88ed756f997",
                             "type": "default",
                             "extras": {},
-                            "x": 601.0000677684142,
-                            "y": 2.2249950369867735,
+                            "x": 571.4999802463032,
+                            "y": 2.6666937950940848,
                             "name": "parameter-out-any-gdrive",
                             "alignment": "right",
-                            "parentNode": "b39b7008-08ab-46df-b03b-a7a50949a66e",
+                            "parentNode": "f7f36402-79f8-4554-9bc2-f5db7ad9c2bb",
                             "links": [
                                 "66bb697d-60e9-4a90-92f3-9ab2d7ccace5"
                             ],
@@ -448,17 +449,17 @@
                     "name": "GDriveServiceAuth",
                     "color": "rgb(15,255,255)",
                     "portsInOrder": [
-                        "d137dfc5-6e85-48bc-9ddc-599d7c4d0d5f",
-                        "8f86266e-fcd3-4f64-a1e6-43b71dc50d21"
+                        "ba13fa34-f79c-40fd-bebc-04bed17ebe7a",
+                        "4a167000-ee2b-4df8-a961-bd6eaa0ed2b7"
                     ],
                     "portsOutOrder": [
-                        "50599ac3-4f0f-48d4-9b6e-040b64ddd0aa",
-                        "5a02ac7b-8376-42d8-be3e-0e59d73f6738",
-                        "ac0fb132-5dd0-44a5-9cd7-e7688a18d46d"
+                        "d7ea6d63-643f-4930-90d2-002d166f9687",
+                        "a36d9bee-1041-4c06-9497-4aff5ab2da93",
+                        "b4211560-5012-4fb1-b067-b88ed756f997"
                     ]
                 },
-                "8a0d9264-7419-4980-85bc-6e6556b93d98": {
-                    "id": "8a0d9264-7419-4980-85bc-6e6556b93d98",
+                "fb1b90f9-fe23-4653-a0df-983e61f01e78": {
+                    "id": "fb1b90f9-fe23-4653-a0df-983e61f01e78",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -468,14 +469,14 @@
                     "y": 129.19530200927454,
                     "ports": [
                         {
-                            "id": "84a24d7c-5f1c-4fce-9bad-4be264b4cd19",
+                            "id": "f74eb53c-5f6d-4ff2-bd73-0661073f5c54",
                             "type": "default",
                             "extras": {},
-                            "x": 882.8999194414683,
-                            "y": 152.98750839562473,
+                            "x": 882.6527616068574,
+                            "y": 153.52780772124385,
                             "name": "parameter-out-0",
                             "alignment": "right",
-                            "parentNode": "8a0d9264-7419-4980-85bc-6e6556b93d98",
+                            "parentNode": "fb1b90f9-fe23-4653-a0df-983e61f01e78",
                             "links": [
                                 "722604af-f81b-4413-9f04-10e2474bc3a6"
                             ],
@@ -490,30 +491,31 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "84a24d7c-5f1c-4fce-9bad-4be264b4cd19"
+                        "f74eb53c-5f6d-4ff2-bd73-0661073f5c54"
                     ]
                 },
-                "80f8d8e6-ca6b-402c-94d5-cdf1f245abe8": {
-                    "id": "80f8d8e6-ca6b-402c-94d5-cdf1f245abe8",
+                "ecedd470-2899-46cb-85f5-7cead6486e19": {
+                    "id": "ecedd470-2899-46cb-85f5-7cead6486e19",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
-                        "type": "string"
+                        "type": "string",
+                        "borderColor": "rgb(0,192,255)"
                     },
                     "x": 185.5697238525827,
                     "y": 6.931151065878282,
                     "ports": [
                         {
-                            "id": "2cc9daca-4561-4010-acb7-69276e6c8fc3",
+                            "id": "a0183f06-db9e-4dfd-9d52-311f3b46e18e",
                             "type": "default",
                             "extras": {},
-                            "x": 369.9124673483079,
-                            "y": 30.725015765907763,
+                            "x": 369.6250263105721,
+                            "y": 31.263898615259176,
                             "name": "parameter-out-0",
                             "alignment": "right",
-                            "parentNode": "80f8d8e6-ca6b-402c-94d5-cdf1f245abe8",
+                            "parentNode": "ecedd470-2899-46cb-85f5-7cead6486e19",
                             "links": [
-                                "3479534e-4629-457e-b1c4-2c040d4a24c4"
+                                "c45c007c-9f3d-48f5-8d27-3e569fdf0830"
                             ],
                             "in": false,
                             "label": "▶",
@@ -526,11 +528,11 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "2cc9daca-4561-4010-acb7-69276e6c8fc3"
+                        "a0183f06-db9e-4dfd-9d52-311f3b46e18e"
                     ]
                 },
-                "4815caf2-b1b8-454d-8ae0-cca354d4a1a0": {
-                    "id": "4815caf2-b1b8-454d-8ae0-cca354d4a1a0",
+                "270d3f0e-6169-4508-85e3-013e2f8526b6": {
+                    "id": "270d3f0e-6169-4508-85e3-013e2f8526b6",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -539,24 +541,23 @@
                         "description": "A component that updates the content of an existing file in Google Drive\nor uploads a new file if no match is found in the specified folder.\n\n##### inPorts:\n- gdrive: the GoogleDrive instance.\n- file_path: the path to the local file whose content will be used.\n- folder_id: the ID of the folder to search within (default is 'root').\n- filename: the name of the file in Google Drive.",
                         "lineNo": [
                             {
-                                "lineno": 212,
-                                "end_lineno": 272
+                                "lineno": 236,
+                                "end_lineno": 301
                             }
-                        ],
-                        "nextNode": "None"
+                        ]
                     },
                     "x": 990.475384229941,
                     "y": -68.91790553789531,
                     "ports": [
                         {
-                            "id": "802f239c-41ed-4eff-a745-5bca6daac34c",
+                            "id": "eaf67686-ad85-429a-92da-a21080722b8f",
                             "type": "default",
                             "extras": {},
-                            "x": 991.2750023571523,
-                            "y": -42.11247409995308,
+                            "x": 991.3611655720697,
+                            "y": -42.02776190950497,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "4815caf2-b1b8-454d-8ae0-cca354d4a1a0",
+                            "parentNode": "270d3f0e-6169-4508-85e3-013e2f8526b6",
                             "links": [
                                 "e5786443-a9f7-4224-96ad-e983ab1f754d"
                             ],
@@ -567,14 +568,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "19f01186-d053-4063-8942-4b5850466a14",
+                            "id": "019b32b8-e90e-4bf0-be90-4c79ff86da06",
                             "type": "default",
                             "extras": {},
-                            "x": 991.2750023571523,
-                            "y": -20.51248930116181,
+                            "x": 991.3611655720697,
+                            "y": -20.249992065017942,
                             "name": "parameter-any-gdrive",
                             "alignment": "left",
-                            "parentNode": "4815caf2-b1b8-454d-8ae0-cca354d4a1a0",
+                            "parentNode": "270d3f0e-6169-4508-85e3-013e2f8526b6",
                             "links": [
                                 "66bb697d-60e9-4a90-92f3-9ab2d7ccace5"
                             ],
@@ -585,14 +586,14 @@
                             "dataType": "any"
                         },
                         {
-                            "id": "1a3d933b-c007-44a0-9510-218625810d05",
+                            "id": "e4447050-086c-470d-b0ca-c41bd6b7ad0a",
                             "type": "default",
                             "extras": {},
-                            "x": 991.2750023571523,
-                            "y": 1.0874954976294624,
+                            "x": 991.3611655720697,
+                            "y": 1.527777779469085,
                             "name": "parameter-string-file_path",
                             "alignment": "left",
-                            "parentNode": "4815caf2-b1b8-454d-8ae0-cca354d4a1a0",
+                            "parentNode": "270d3f0e-6169-4508-85e3-013e2f8526b6",
                             "links": [
                                 "93edb9d4-0cc7-4323-bf1b-2ce8411cb60a"
                             ],
@@ -603,14 +604,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "17060cc9-701a-4140-9617-bb24a2682a94",
+                            "id": "7cb6b982-6c96-4241-8c4f-b53754b074a7",
                             "type": "default",
                             "extras": {},
-                            "x": 991.2750023571523,
-                            "y": 22.687514844622385,
+                            "x": 991.3611655720697,
+                            "y": 23.305547623956112,
                             "name": "parameter-string-folder_id",
                             "alignment": "left",
-                            "parentNode": "4815caf2-b1b8-454d-8ae0-cca354d4a1a0",
+                            "parentNode": "270d3f0e-6169-4508-85e3-013e2f8526b6",
                             "links": [
                                 "722604af-f81b-4413-9f04-10e2474bc3a6"
                             ],
@@ -621,14 +622,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "9d722fde-8c3e-4645-bc52-07e458d48431",
+                            "id": "c025a969-58b8-42c6-a6c9-e397d5909e15",
                             "type": "default",
                             "extras": {},
-                            "x": 991.2750023571523,
-                            "y": 44.28753419161531,
+                            "x": 991.3611655720697,
+                            "y": 45.08335201664479,
                             "name": "parameter-string-filename",
                             "alignment": "left",
-                            "parentNode": "4815caf2-b1b8-454d-8ae0-cca354d4a1a0",
+                            "parentNode": "270d3f0e-6169-4508-85e3-013e2f8526b6",
                             "links": [
                                 "de54daa8-e2ca-432c-b720-4cf27c85a7cf"
                             ],
@@ -639,14 +640,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "a2945246-af38-41a7-8c03-7cdb7a70b481",
+                            "id": "e0dc188d-d5b5-4202-a187-eefd949c7640",
                             "type": "default",
                             "extras": {},
-                            "x": 1143.4750318382844,
-                            "y": -42.11247409995308,
+                            "x": 1143.2777616068574,
+                            "y": -42.02776190950497,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "4815caf2-b1b8-454d-8ae0-cca354d4a1a0",
+                            "parentNode": "270d3f0e-6169-4508-85e3-013e2f8526b6",
                             "links": [
                                 "87fcaf42-5686-4b97-af9c-228a4550ba15"
                             ],
@@ -660,18 +661,18 @@
                     "name": "UpdateFileInGDrive",
                     "color": "rgb(153,204,204)",
                     "portsInOrder": [
-                        "802f239c-41ed-4eff-a745-5bca6daac34c",
-                        "19f01186-d053-4063-8942-4b5850466a14",
-                        "1a3d933b-c007-44a0-9510-218625810d05",
-                        "17060cc9-701a-4140-9617-bb24a2682a94",
-                        "9d722fde-8c3e-4645-bc52-07e458d48431"
+                        "eaf67686-ad85-429a-92da-a21080722b8f",
+                        "019b32b8-e90e-4bf0-be90-4c79ff86da06",
+                        "e4447050-086c-470d-b0ca-c41bd6b7ad0a",
+                        "7cb6b982-6c96-4241-8c4f-b53754b074a7",
+                        "c025a969-58b8-42c6-a6c9-e397d5909e15"
                     ],
                     "portsOutOrder": [
-                        "a2945246-af38-41a7-8c03-7cdb7a70b481"
+                        "e0dc188d-d5b5-4202-a187-eefd949c7640"
                     ]
                 },
-                "c9dfe981-82af-4ea9-976b-67e57b1993dc": {
-                    "id": "c9dfe981-82af-4ea9-976b-67e57b1993dc",
+                "ea4f1050-3013-41ae-bacb-36bdc81bfc03": {
+                    "id": "ea4f1050-3013-41ae-bacb-36bdc81bfc03",
                     "type": "custom-node",
                     "selected": false,
                     "extras": {
@@ -682,14 +683,14 @@
                     "y": 48.97250943396227,
                     "ports": [
                         {
-                            "id": "f84fb78b-6a20-4ee1-ac67-3d599ae2f228",
+                            "id": "d763e803-b420-440f-8c59-e70750888b39",
                             "type": "default",
                             "extras": {},
-                            "x": 886.437448001315,
-                            "y": 72.76250747433936,
+                            "x": 886.2221436086263,
+                            "y": 73.30560520429219,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "c9dfe981-82af-4ea9-976b-67e57b1993dc",
+                            "parentNode": "ea4f1050-3013-41ae-bacb-36bdc81bfc03",
                             "links": [
                                 "93edb9d4-0cc7-4323-bf1b-2ce8411cb60a"
                             ],
@@ -704,13 +705,13 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "f84fb78b-6a20-4ee1-ac67-3d599ae2f228"
+                        "d763e803-b420-440f-8c59-e70750888b39"
                     ]
                 },
-                "b1742226-af28-4c68-840a-c384bb5f3b5a": {
-                    "id": "b1742226-af28-4c68-840a-c384bb5f3b5a",
+                "cae51895-900e-499e-bb1b-642450e782cb": {
+                    "id": "cae51895-900e-499e-bb1b-642450e782cb",
                     "type": "custom-node",
-                    "selected": true,
+                    "selected": false,
                     "extras": {
                         "type": "string",
                         "attached": false
@@ -719,14 +720,14 @@
                     "y": 218.23369811320757,
                     "ports": [
                         {
-                            "id": "56f24bff-dd06-44c7-b28f-e3c1fb83a745",
+                            "id": "4ac67426-c2bc-48e2-b29d-13ac6ba8ff08",
                             "type": "default",
                             "extras": {},
-                            "x": 890.4750272318574,
-                            "y": 242.0249609494278,
+                            "x": 890.5138594105132,
+                            "y": 242.55555223038297,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "b1742226-af28-4c68-840a-c384bb5f3b5a",
+                            "parentNode": "cae51895-900e-499e-bb1b-642450e782cb",
                             "links": [
                                 "de54daa8-e2ca-432c-b720-4cf27c85a7cf"
                             ],
@@ -741,7 +742,7 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "56f24bff-dd06-44c7-b28f-e3c1fb83a745"
+                        "4ac67426-c2bc-48e2-b29d-13ac6ba8ff08"
                     ]
                 }
             }

--- a/examples/GDriveSimpleUpdate.xircuits
+++ b/examples/GDriveSimpleUpdate.xircuits
@@ -6,7 +6,7 @@
     "gridSize": 0,
     "layers": [
         {
-            "id": "f5b19187-f02a-4477-bcc4-0b0fa17fbc73",
+            "id": "6ccfefad-132e-41fa-b05e-7846a8992869",
             "type": "diagram-links",
             "isSvg": true,
             "transformed": true,
@@ -17,8 +17,8 @@
                     "selected": false,
                     "source": "e705a570-8daf-4330-8c6b-9d8fceda6bd7",
                     "sourcePort": "1b8ccda9-ffba-4b17-8d65-652de327b62d",
-                    "target": "f7f36402-79f8-4554-9bc2-f5db7ad9c2bb",
-                    "targetPort": "ba13fa34-f79c-40fd-bebc-04bed17ebe7a",
+                    "target": "cccc1f52-a98a-4302-a831-212e6b1099e6",
+                    "targetPort": "b32ae371-8de0-4bce-9980-dfe20cbc6c10",
                     "points": [
                         {
                             "id": "cda35395-1baf-4a71-a98b-2df219d99447",
@@ -43,15 +43,15 @@
                     "id": "e5786443-a9f7-4224-96ad-e983ab1f754d",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "f7f36402-79f8-4554-9bc2-f5db7ad9c2bb",
-                    "sourcePort": "d7ea6d63-643f-4930-90d2-002d166f9687",
-                    "target": "270d3f0e-6169-4508-85e3-013e2f8526b6",
-                    "targetPort": "eaf67686-ad85-429a-92da-a21080722b8f",
+                    "source": "cccc1f52-a98a-4302-a831-212e6b1099e6",
+                    "sourcePort": "31b84f7f-7858-43fc-a85f-a0de4718e02a",
+                    "target": "b4cc8d07-f1e0-4616-9d81-481822825c89",
+                    "targetPort": "c7586e9e-af22-4cc1-b56d-fc4c8b585154",
                     "points": [
                         {
                             "id": "548e8cb7-be53-438f-9e1f-7f9cc3b4ffca",
                             "type": "point",
-                            "x": 581.8888857535169,
+                            "x": 602.7083921288117,
                             "y": -30.49999004970618
                         },
                         {
@@ -71,15 +71,15 @@
                     "id": "66bb697d-60e9-4a90-92f3-9ab2d7ccace5",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "f7f36402-79f8-4554-9bc2-f5db7ad9c2bb",
-                    "sourcePort": "b4211560-5012-4fb1-b067-b88ed756f997",
-                    "target": "270d3f0e-6169-4508-85e3-013e2f8526b6",
-                    "targetPort": "019b32b8-e90e-4bf0-be90-4c79ff86da06",
+                    "source": "cccc1f52-a98a-4302-a831-212e6b1099e6",
+                    "sourcePort": "4b448c22-4aef-4493-819e-f71e483d1c58",
+                    "target": "b4cc8d07-f1e0-4616-9d81-481822825c89",
+                    "targetPort": "6da7a7ed-3675-4b90-9178-31fbd58b60c6",
                     "points": [
                         {
                             "id": "81d8449b-c0a7-4c3c-945a-de42c396debd",
                             "type": "point",
-                            "x": 581.8888857535169,
+                            "x": 602.7083921288117,
                             "y": 13.055584187469526
                         },
                         {
@@ -99,10 +99,10 @@
                     "id": "722604af-f81b-4413-9f04-10e2474bc3a6",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "fb1b90f9-fe23-4653-a0df-983e61f01e78",
-                    "sourcePort": "f74eb53c-5f6d-4ff2-bd73-0661073f5c54",
-                    "target": "270d3f0e-6169-4508-85e3-013e2f8526b6",
-                    "targetPort": "7cb6b982-6c96-4241-8c4f-b53754b074a7",
+                    "source": "8bd2b3d5-bcb5-4089-8c5d-f1404dea82c5",
+                    "sourcePort": "f23b8d90-6647-4571-9ca3-dc31f657c5ea",
+                    "target": "b4cc8d07-f1e0-4616-9d81-481822825c89",
+                    "targetPort": "3521804b-9b49-4e9f-b014-bd284c1c7dc7",
                     "points": [
                         {
                             "id": "bc5e5912-bfd1-4738-9a31-1ac25ed3bb4a",
@@ -127,10 +127,10 @@
                     "id": "87fcaf42-5686-4b97-af9c-228a4550ba15",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "270d3f0e-6169-4508-85e3-013e2f8526b6",
-                    "sourcePort": "e0dc188d-d5b5-4202-a187-eefd949c7640",
-                    "target": "48ff9f23-c64f-4238-8fa7-d860592fdf50",
-                    "targetPort": "de027635-480c-46f4-9e1a-59931de9d4d5",
+                    "source": "b4cc8d07-f1e0-4616-9d81-481822825c89",
+                    "sourcePort": "44f709fe-c72a-4bd1-83e2-2fffd3beb87e",
+                    "target": "216f12ea-26e0-41f3-aa52-a86726bf91e5",
+                    "targetPort": "10e39cca-82a1-42f0-bcd1-b8dad0c610f0",
                     "points": [
                         {
                             "id": "b2f8cf1b-8b6f-47e2-a3ff-004c8a091875",
@@ -155,15 +155,15 @@
                     "id": "93edb9d4-0cc7-4323-bf1b-2ce8411cb60a",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "ea4f1050-3013-41ae-bacb-36bdc81bfc03",
-                    "sourcePort": "d763e803-b420-440f-8c59-e70750888b39",
-                    "target": "270d3f0e-6169-4508-85e3-013e2f8526b6",
-                    "targetPort": "e4447050-086c-470d-b0ca-c41bd6b7ad0a",
+                    "source": "2d2439e6-a1fb-4a91-a27d-7442678c453d",
+                    "sourcePort": "a20fb4ed-2290-4ae9-a583-16c721ba0fbb",
+                    "target": "b4cc8d07-f1e0-4616-9d81-481822825c89",
+                    "targetPort": "2c44cc7f-51d3-48ef-be34-d6c26b222131",
                     "points": [
                         {
                             "id": "04cf17b2-250e-466a-b220-ea5c01c3f909",
                             "type": "point",
-                            "x": 896.6110491158399,
+                            "x": 896.6111182122434,
                             "y": 83.69447940219811
                         },
                         {
@@ -183,15 +183,15 @@
                     "id": "de54daa8-e2ca-432c-b720-4cf27c85a7cf",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "cae51895-900e-499e-bb1b-642450e782cb",
-                    "sourcePort": "4ac67426-c2bc-48e2-b29d-13ac6ba8ff08",
-                    "target": "270d3f0e-6169-4508-85e3-013e2f8526b6",
-                    "targetPort": "c025a969-58b8-42c6-a6c9-e397d5909e15",
+                    "source": "82d8d430-9a98-480e-a6bb-d47d2428fcc5",
+                    "sourcePort": "a93c949d-4e8b-4a10-a8b2-bfdc8e4dad19",
+                    "target": "b4cc8d07-f1e0-4616-9d81-481822825c89",
+                    "targetPort": "ef70a16c-f68d-47e8-8fe0-cc0a8e879bf4",
                     "points": [
                         {
                             "id": "661a7c99-4670-4194-a2b2-a6a2b4fd5b0d",
                             "type": "point",
-                            "x": 900.9027649177269,
+                            "x": 900.9028340141301,
                             "y": 252.94445773759662
                         },
                         {
@@ -206,39 +206,11 @@
                     "color": "gray",
                     "curvyness": 50,
                     "selectedColor": "rgb(0,192,255)"
-                },
-                "c45c007c-9f3d-48f5-8d27-3e569fdf0830": {
-                    "id": "c45c007c-9f3d-48f5-8d27-3e569fdf0830",
-                    "type": "triangle-link",
-                    "selected": true,
-                    "source": "ecedd470-2899-46cb-85f5-7cead6486e19",
-                    "sourcePort": "a0183f06-db9e-4dfd-9d52-311f3b46e18e",
-                    "target": "f7f36402-79f8-4554-9bc2-f5db7ad9c2bb",
-                    "targetPort": "4a167000-ee2b-4df8-a961-bd6eaa0ed2b7",
-                    "points": [
-                        {
-                            "id": "91fd73cf-9600-4c01-9576-689c7eb029e7",
-                            "type": "point",
-                            "x": 380.01393181778576,
-                            "y": 41.65278900763462
-                        },
-                        {
-                            "id": "03e820e3-208d-46cd-8044-d9e5e2c0c8e9",
-                            "type": "point",
-                            "x": 433.44442177174454,
-                            "y": -8.722220205219152
-                        }
-                    ],
-                    "labels": [],
-                    "width": 3,
-                    "color": "gray",
-                    "curvyness": 50,
-                    "selectedColor": "rgb(0,192,255)"
                 }
             }
         },
         {
-            "id": "066e69db-d3a4-4ced-92b9-2329cb5ed6f5",
+            "id": "981db12e-8f71-426f-92d6-dd44b7d44ac7",
             "type": "diagram-nodes",
             "isSvg": false,
             "transformed": true,
@@ -280,10 +252,10 @@
                         "1b8ccda9-ffba-4b17-8d65-652de327b62d"
                     ]
                 },
-                "48ff9f23-c64f-4238-8fa7-d860592fdf50": {
-                    "id": "48ff9f23-c64f-4238-8fa7-d860592fdf50",
+                "216f12ea-26e0-41f3-aa52-a86726bf91e5": {
+                    "id": "216f12ea-26e0-41f3-aa52-a86726bf91e5",
                     "type": "custom-node",
-                    "selected": false,
+                    "selected": true,
                     "extras": {
                         "type": "Finish"
                     },
@@ -291,14 +263,14 @@
                     "y": -68.85158490566037,
                     "ports": [
                         {
-                            "id": "de027635-480c-46f4-9e1a-59931de9d4d5",
+                            "id": "10e39cca-82a1-42f0-bcd1-b8dad0c610f0",
                             "type": "default",
                             "extras": {},
                             "x": 1246.680529148131,
                             "y": -41.95832002418657,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "48ff9f23-c64f-4238-8fa7-d860592fdf50",
+                            "parentNode": "216f12ea-26e0-41f3-aa52-a86726bf91e5",
                             "links": [
                                 "87fcaf42-5686-4b97-af9c-228a4550ba15"
                             ],
@@ -309,14 +281,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "bd73985b-52d7-4553-9988-7156c09bbb23",
+                            "id": "8fbc9f63-22ba-46d1-bc57-883e3f99022a",
                             "type": "default",
                             "extras": {},
                             "x": 1246.680529148131,
                             "y": -20.180550179699544,
                             "name": "parameter-dynalist-outputs",
                             "alignment": "left",
-                            "parentNode": "48ff9f23-c64f-4238-8fa7-d860592fdf50",
+                            "parentNode": "216f12ea-26e0-41f3-aa52-a86726bf91e5",
                             "links": [],
                             "in": true,
                             "label": "outputs",
@@ -333,15 +305,15 @@
                     "name": "Finish",
                     "color": "rgb(255,102,102)",
                     "portsInOrder": [
-                        "de027635-480c-46f4-9e1a-59931de9d4d5",
-                        "bd73985b-52d7-4553-9988-7156c09bbb23"
+                        "10e39cca-82a1-42f0-bcd1-b8dad0c610f0",
+                        "8fbc9f63-22ba-46d1-bc57-883e3f99022a"
                     ],
                     "portsOutOrder": []
                 },
-                "f7f36402-79f8-4554-9bc2-f5db7ad9c2bb": {
-                    "id": "f7f36402-79f8-4554-9bc2-f5db7ad9c2bb",
+                "cccc1f52-a98a-4302-a831-212e6b1099e6": {
+                    "id": "cccc1f52-a98a-4302-a831-212e6b1099e6",
                     "type": "custom-node",
-                    "selected": false,
+                    "selected": true,
                     "extras": {
                         "type": "library_component",
                         "path": "xai_components/xai_gdrive/gdrive_components.py",
@@ -351,21 +323,20 @@
                                 "lineno": 18,
                                 "end_lineno": 64
                             }
-                        ],
-                        "borderColor": "rgb(0,192,255)"
+                        ]
                     },
                     "x": 422.17349743748844,
                     "y": -67.78583006619719,
                     "ports": [
                         {
-                            "id": "ba13fa34-f79c-40fd-bebc-04bed17ebe7a",
+                            "id": "b32ae371-8de0-4bce-9980-dfe20cbc6c10",
                             "type": "default",
                             "extras": {},
                             "x": 423.0555475738386,
                             "y": -40.88888044208162,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "f7f36402-79f8-4554-9bc2-f5db7ad9c2bb",
+                            "parentNode": "cccc1f52-a98a-4302-a831-212e6b1099e6",
                             "links": [
                                 "a617ca34-5835-422e-ab32-361f84f4fc6d"
                             ],
@@ -376,32 +347,30 @@
                             "dataType": ""
                         },
                         {
-                            "id": "4a167000-ee2b-4df8-a961-bd6eaa0ed2b7",
+                            "id": "25791726-86b1-4b1d-b7b1-01400650b3bc",
                             "type": "default",
                             "extras": {},
                             "x": 423.0555475738386,
                             "y": -19.111110597594593,
-                            "name": "parameter-string-json_path",
+                            "name": "parameter-string-service_json_path",
                             "alignment": "left",
-                            "parentNode": "f7f36402-79f8-4554-9bc2-f5db7ad9c2bb",
-                            "links": [
-                                "c45c007c-9f3d-48f5-8d27-3e569fdf0830"
-                            ],
+                            "parentNode": "cccc1f52-a98a-4302-a831-212e6b1099e6",
+                            "links": [],
                             "in": true,
-                            "label": "json_path",
-                            "varName": "json_path",
+                            "label": "service_json_path",
+                            "varName": "service_json_path",
                             "portType": "",
                             "dataType": "string"
                         },
                         {
-                            "id": "d7ea6d63-643f-4930-90d2-002d166f9687",
+                            "id": "31b84f7f-7858-43fc-a85f-a0de4718e02a",
                             "type": "default",
                             "extras": {},
-                            "x": 571.4999802463032,
+                            "x": 592.3194866215981,
                             "y": -40.88888044208162,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "f7f36402-79f8-4554-9bc2-f5db7ad9c2bb",
+                            "parentNode": "cccc1f52-a98a-4302-a831-212e6b1099e6",
                             "links": [
                                 "e5786443-a9f7-4224-96ad-e983ab1f754d"
                             ],
@@ -412,14 +381,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "a36d9bee-1041-4c06-9497-4aff5ab2da93",
+                            "id": "5f729635-d54c-419b-a8a2-43c6ebd3c906",
                             "type": "default",
                             "extras": {},
-                            "x": 571.4999802463032,
+                            "x": 592.3194866215981,
                             "y": -19.111110597594593,
                             "name": "parameter-out-any-gauth",
                             "alignment": "right",
-                            "parentNode": "f7f36402-79f8-4554-9bc2-f5db7ad9c2bb",
+                            "parentNode": "cccc1f52-a98a-4302-a831-212e6b1099e6",
                             "links": [],
                             "in": false,
                             "label": "gauth",
@@ -428,14 +397,14 @@
                             "dataType": "any"
                         },
                         {
-                            "id": "b4211560-5012-4fb1-b067-b88ed756f997",
+                            "id": "4b448c22-4aef-4493-819e-f71e483d1c58",
                             "type": "default",
                             "extras": {},
-                            "x": 571.4999802463032,
+                            "x": 592.3194866215981,
                             "y": 2.6666937950940848,
                             "name": "parameter-out-any-gdrive",
                             "alignment": "right",
-                            "parentNode": "f7f36402-79f8-4554-9bc2-f5db7ad9c2bb",
+                            "parentNode": "cccc1f52-a98a-4302-a831-212e6b1099e6",
                             "links": [
                                 "66bb697d-60e9-4a90-92f3-9ab2d7ccace5"
                             ],
@@ -449,19 +418,19 @@
                     "name": "GDriveServiceAuth",
                     "color": "rgb(15,255,255)",
                     "portsInOrder": [
-                        "ba13fa34-f79c-40fd-bebc-04bed17ebe7a",
-                        "4a167000-ee2b-4df8-a961-bd6eaa0ed2b7"
+                        "b32ae371-8de0-4bce-9980-dfe20cbc6c10",
+                        "25791726-86b1-4b1d-b7b1-01400650b3bc"
                     ],
                     "portsOutOrder": [
-                        "d7ea6d63-643f-4930-90d2-002d166f9687",
-                        "a36d9bee-1041-4c06-9497-4aff5ab2da93",
-                        "b4211560-5012-4fb1-b067-b88ed756f997"
+                        "31b84f7f-7858-43fc-a85f-a0de4718e02a",
+                        "5f729635-d54c-419b-a8a2-43c6ebd3c906",
+                        "4b448c22-4aef-4493-819e-f71e483d1c58"
                     ]
                 },
-                "fb1b90f9-fe23-4653-a0df-983e61f01e78": {
-                    "id": "fb1b90f9-fe23-4653-a0df-983e61f01e78",
+                "8bd2b3d5-bcb5-4089-8c5d-f1404dea82c5": {
+                    "id": "8bd2b3d5-bcb5-4089-8c5d-f1404dea82c5",
                     "type": "custom-node",
-                    "selected": false,
+                    "selected": true,
                     "extras": {
                         "type": "string"
                     },
@@ -469,14 +438,14 @@
                     "y": 129.19530200927454,
                     "ports": [
                         {
-                            "id": "f74eb53c-5f6d-4ff2-bd73-0661073f5c54",
+                            "id": "f23b8d90-6647-4571-9ca3-dc31f657c5ea",
                             "type": "default",
                             "extras": {},
                             "x": 882.6527616068574,
                             "y": 153.52780772124385,
                             "name": "parameter-out-0",
                             "alignment": "right",
-                            "parentNode": "fb1b90f9-fe23-4653-a0df-983e61f01e78",
+                            "parentNode": "8bd2b3d5-bcb5-4089-8c5d-f1404dea82c5",
                             "links": [
                                 "722604af-f81b-4413-9f04-10e2474bc3a6"
                             ],
@@ -491,32 +460,29 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "f74eb53c-5f6d-4ff2-bd73-0661073f5c54"
+                        "f23b8d90-6647-4571-9ca3-dc31f657c5ea"
                     ]
                 },
-                "ecedd470-2899-46cb-85f5-7cead6486e19": {
-                    "id": "ecedd470-2899-46cb-85f5-7cead6486e19",
+                "6f3aa3c2-bf48-41b8-adf4-ebaec80428be": {
+                    "id": "6f3aa3c2-bf48-41b8-adf4-ebaec80428be",
                     "type": "custom-node",
-                    "selected": false,
+                    "selected": true,
                     "extras": {
-                        "type": "string",
-                        "borderColor": "rgb(0,192,255)"
+                        "type": "string"
                     },
                     "x": 185.5697238525827,
                     "y": 6.931151065878282,
                     "ports": [
                         {
-                            "id": "a0183f06-db9e-4dfd-9d52-311f3b46e18e",
+                            "id": "fa643b1b-0422-4189-b9d6-b534f519ba21",
                             "type": "default",
                             "extras": {},
-                            "x": 369.6250263105721,
+                            "x": 369.6249917623704,
                             "y": 31.263898615259176,
                             "name": "parameter-out-0",
                             "alignment": "right",
-                            "parentNode": "ecedd470-2899-46cb-85f5-7cead6486e19",
-                            "links": [
-                                "c45c007c-9f3d-48f5-8d27-3e569fdf0830"
-                            ],
+                            "parentNode": "6f3aa3c2-bf48-41b8-adf4-ebaec80428be",
+                            "links": [],
                             "in": false,
                             "label": "▶",
                             "varName": "▶",
@@ -528,13 +494,13 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "a0183f06-db9e-4dfd-9d52-311f3b46e18e"
+                        "fa643b1b-0422-4189-b9d6-b534f519ba21"
                     ]
                 },
-                "270d3f0e-6169-4508-85e3-013e2f8526b6": {
-                    "id": "270d3f0e-6169-4508-85e3-013e2f8526b6",
+                "b4cc8d07-f1e0-4616-9d81-481822825c89": {
+                    "id": "b4cc8d07-f1e0-4616-9d81-481822825c89",
                     "type": "custom-node",
-                    "selected": false,
+                    "selected": true,
                     "extras": {
                         "type": "library_component",
                         "path": "xai_components/xai_gdrive/gdrive_components.py",
@@ -550,14 +516,14 @@
                     "y": -68.91790553789531,
                     "ports": [
                         {
-                            "id": "eaf67686-ad85-429a-92da-a21080722b8f",
+                            "id": "c7586e9e-af22-4cc1-b56d-fc4c8b585154",
                             "type": "default",
                             "extras": {},
                             "x": 991.3611655720697,
                             "y": -42.02776190950497,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "270d3f0e-6169-4508-85e3-013e2f8526b6",
+                            "parentNode": "b4cc8d07-f1e0-4616-9d81-481822825c89",
                             "links": [
                                 "e5786443-a9f7-4224-96ad-e983ab1f754d"
                             ],
@@ -568,14 +534,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "019b32b8-e90e-4bf0-be90-4c79ff86da06",
+                            "id": "6da7a7ed-3675-4b90-9178-31fbd58b60c6",
                             "type": "default",
                             "extras": {},
                             "x": 991.3611655720697,
                             "y": -20.249992065017942,
                             "name": "parameter-any-gdrive",
                             "alignment": "left",
-                            "parentNode": "270d3f0e-6169-4508-85e3-013e2f8526b6",
+                            "parentNode": "b4cc8d07-f1e0-4616-9d81-481822825c89",
                             "links": [
                                 "66bb697d-60e9-4a90-92f3-9ab2d7ccace5"
                             ],
@@ -586,14 +552,14 @@
                             "dataType": "any"
                         },
                         {
-                            "id": "e4447050-086c-470d-b0ca-c41bd6b7ad0a",
+                            "id": "2c44cc7f-51d3-48ef-be34-d6c26b222131",
                             "type": "default",
                             "extras": {},
                             "x": 991.3611655720697,
                             "y": 1.527777779469085,
                             "name": "parameter-string-file_path",
                             "alignment": "left",
-                            "parentNode": "270d3f0e-6169-4508-85e3-013e2f8526b6",
+                            "parentNode": "b4cc8d07-f1e0-4616-9d81-481822825c89",
                             "links": [
                                 "93edb9d4-0cc7-4323-bf1b-2ce8411cb60a"
                             ],
@@ -604,14 +570,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "7cb6b982-6c96-4241-8c4f-b53754b074a7",
+                            "id": "3521804b-9b49-4e9f-b014-bd284c1c7dc7",
                             "type": "default",
                             "extras": {},
                             "x": 991.3611655720697,
                             "y": 23.305547623956112,
                             "name": "parameter-string-folder_id",
                             "alignment": "left",
-                            "parentNode": "270d3f0e-6169-4508-85e3-013e2f8526b6",
+                            "parentNode": "b4cc8d07-f1e0-4616-9d81-481822825c89",
                             "links": [
                                 "722604af-f81b-4413-9f04-10e2474bc3a6"
                             ],
@@ -622,14 +588,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "c025a969-58b8-42c6-a6c9-e397d5909e15",
+                            "id": "ef70a16c-f68d-47e8-8fe0-cc0a8e879bf4",
                             "type": "default",
                             "extras": {},
                             "x": 991.3611655720697,
                             "y": 45.08335201664479,
                             "name": "parameter-string-filename",
                             "alignment": "left",
-                            "parentNode": "270d3f0e-6169-4508-85e3-013e2f8526b6",
+                            "parentNode": "b4cc8d07-f1e0-4616-9d81-481822825c89",
                             "links": [
                                 "de54daa8-e2ca-432c-b720-4cf27c85a7cf"
                             ],
@@ -640,14 +606,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "e0dc188d-d5b5-4202-a187-eefd949c7640",
+                            "id": "44f709fe-c72a-4bd1-83e2-2fffd3beb87e",
                             "type": "default",
                             "extras": {},
                             "x": 1143.2777616068574,
                             "y": -42.02776190950497,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "270d3f0e-6169-4508-85e3-013e2f8526b6",
+                            "parentNode": "b4cc8d07-f1e0-4616-9d81-481822825c89",
                             "links": [
                                 "87fcaf42-5686-4b97-af9c-228a4550ba15"
                             ],
@@ -661,20 +627,20 @@
                     "name": "UpdateFileInGDrive",
                     "color": "rgb(153,204,204)",
                     "portsInOrder": [
-                        "eaf67686-ad85-429a-92da-a21080722b8f",
-                        "019b32b8-e90e-4bf0-be90-4c79ff86da06",
-                        "e4447050-086c-470d-b0ca-c41bd6b7ad0a",
-                        "7cb6b982-6c96-4241-8c4f-b53754b074a7",
-                        "c025a969-58b8-42c6-a6c9-e397d5909e15"
+                        "c7586e9e-af22-4cc1-b56d-fc4c8b585154",
+                        "6da7a7ed-3675-4b90-9178-31fbd58b60c6",
+                        "2c44cc7f-51d3-48ef-be34-d6c26b222131",
+                        "3521804b-9b49-4e9f-b014-bd284c1c7dc7",
+                        "ef70a16c-f68d-47e8-8fe0-cc0a8e879bf4"
                     ],
                     "portsOutOrder": [
-                        "e0dc188d-d5b5-4202-a187-eefd949c7640"
+                        "44f709fe-c72a-4bd1-83e2-2fffd3beb87e"
                     ]
                 },
-                "ea4f1050-3013-41ae-bacb-36bdc81bfc03": {
-                    "id": "ea4f1050-3013-41ae-bacb-36bdc81bfc03",
+                "2d2439e6-a1fb-4a91-a27d-7442678c453d": {
+                    "id": "2d2439e6-a1fb-4a91-a27d-7442678c453d",
                     "type": "custom-node",
-                    "selected": false,
+                    "selected": true,
                     "extras": {
                         "type": "string",
                         "attached": false
@@ -683,14 +649,14 @@
                     "y": 48.97250943396227,
                     "ports": [
                         {
-                            "id": "d763e803-b420-440f-8c59-e70750888b39",
+                            "id": "a20fb4ed-2290-4ae9-a583-16c721ba0fbb",
                             "type": "default",
                             "extras": {},
-                            "x": 886.2221436086263,
+                            "x": 886.2222127050296,
                             "y": 73.30560520429219,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "ea4f1050-3013-41ae-bacb-36bdc81bfc03",
+                            "parentNode": "2d2439e6-a1fb-4a91-a27d-7442678c453d",
                             "links": [
                                 "93edb9d4-0cc7-4323-bf1b-2ce8411cb60a"
                             ],
@@ -705,13 +671,13 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "d763e803-b420-440f-8c59-e70750888b39"
+                        "a20fb4ed-2290-4ae9-a583-16c721ba0fbb"
                     ]
                 },
-                "cae51895-900e-499e-bb1b-642450e782cb": {
-                    "id": "cae51895-900e-499e-bb1b-642450e782cb",
+                "82d8d430-9a98-480e-a6bb-d47d2428fcc5": {
+                    "id": "82d8d430-9a98-480e-a6bb-d47d2428fcc5",
                     "type": "custom-node",
-                    "selected": false,
+                    "selected": true,
                     "extras": {
                         "type": "string",
                         "attached": false
@@ -720,14 +686,14 @@
                     "y": 218.23369811320757,
                     "ports": [
                         {
-                            "id": "4ac67426-c2bc-48e2-b29d-13ac6ba8ff08",
+                            "id": "a93c949d-4e8b-4a10-a8b2-bfdc8e4dad19",
                             "type": "default",
                             "extras": {},
-                            "x": 890.5138594105132,
+                            "x": 890.5139285069165,
                             "y": 242.55555223038297,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "cae51895-900e-499e-bb1b-642450e782cb",
+                            "parentNode": "82d8d430-9a98-480e-a6bb-d47d2428fcc5",
                             "links": [
                                 "de54daa8-e2ca-432c-b720-4cf27c85a7cf"
                             ],
@@ -742,7 +708,7 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "4ac67426-c2bc-48e2-b29d-13ac6ba8ff08"
+                        "a93c949d-4e8b-4a10-a8b2-bfdc8e4dad19"
                     ]
                 }
             }

--- a/examples/GDriveSimpleUpload.xircuits
+++ b/examples/GDriveSimpleUpload.xircuits
@@ -6,7 +6,7 @@
     "gridSize": 0,
     "layers": [
         {
-            "id": "4074301d-1a9d-4863-91e6-2dbd7f604ef1",
+            "id": "b7c7ecdf-b650-456f-bcd7-bb2fe7446215",
             "type": "diagram-links",
             "isSvg": true,
             "transformed": true,
@@ -15,10 +15,10 @@
                     "id": "29614add-7959-4822-9f34-2a6c225b8a34",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "bf87304b-af64-456c-ae49-a62e4364e285",
-                    "sourcePort": "d7cd6c33-1f6a-46e9-bd74-b5c0a2839c15",
-                    "target": "caf4c4c1-7665-4367-946b-4ec85864bc4b",
-                    "targetPort": "8c0d04d7-8455-44b7-9910-834bdf9915bc",
+                    "source": "c94a97a6-b7e6-4f4d-8df6-894aab284d88",
+                    "sourcePort": "40559040-0dad-41dc-952d-e4bc9b380730",
+                    "target": "01719176-6453-496d-bdba-ca88dacc7e0b",
+                    "targetPort": "e3dc3862-a6a0-4145-a82a-f883d2a70ddf",
                     "points": [
                         {
                             "id": "35e75aa2-8131-432e-b8fe-2173c0c32ee4",
@@ -43,21 +43,21 @@
                     "id": "927da9f3-873f-448f-9571-39ff0da434a1",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "30a0462e-c687-4969-a875-a69af2e80032",
-                    "sourcePort": "4c5c3d12-8512-4e45-8f37-a295dbea9802",
-                    "target": "bf87304b-af64-456c-ae49-a62e4364e285",
-                    "targetPort": "941557c2-d926-427f-9c39-0c4b150e1ffb",
+                    "source": "29c3573a-139f-46c2-96a7-2924e65639dd",
+                    "sourcePort": "8b52d561-7053-46c2-b6d2-82fe56c86bc5",
+                    "target": "c94a97a6-b7e6-4f4d-8df6-894aab284d88",
+                    "targetPort": "826c57e6-1607-431e-9dc1-82e91bdca8cc",
                     "points": [
                         {
                             "id": "4b290c64-c640-49c6-86fb-506640f17e04",
                             "type": "point",
-                            "x": 905.6667546361821,
+                            "x": 905.6667233268743,
                             "y": 178.77779490961905
                         },
                         {
                             "id": "d7bb9686-ed83-4343-8486-bd1490459985",
                             "type": "point",
-                            "x": 987.3749174117614,
+                            "x": 987.3749865081647,
                             "y": 103.33335172874311
                         }
                     ],
@@ -73,19 +73,19 @@
                     "selected": false,
                     "source": "e705a570-8daf-4330-8c6b-9d8fceda6bd7",
                     "sourcePort": "1b8ccda9-ffba-4b17-8d65-652de327b62d",
-                    "target": "2bdec2e5-37f7-491d-a1eb-45643e1255f4",
-                    "targetPort": "f4cf8ea6-4f2b-4c53-a863-5d50780048b0",
+                    "target": "c1499a33-b3c8-4841-be1d-e137aee05400",
+                    "targetPort": "e88238e6-f849-4b1a-83c6-92176b066387",
                     "points": [
                         {
                             "id": "cda35395-1baf-4a71-a98b-2df219d99447",
                             "type": "point",
-                            "x": 196.01387517313015,
+                            "x": 196.0139097213318,
                             "y": 62.5555565489082
                         },
                         {
                             "id": "f04339b9-3ce7-447e-8fe6-737323970cff",
                             "type": "point",
-                            "x": 462.87499831213364,
+                            "x": 462.8750328603353,
                             "y": 61.18055323803888
                         }
                     ],
@@ -99,21 +99,21 @@
                     "id": "52f4085e-237d-43b9-ac10-769148722565",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "2bdec2e5-37f7-491d-a1eb-45643e1255f4",
-                    "sourcePort": "1ea85e57-ff38-4a9e-947e-6262ab4aac58",
-                    "target": "bf87304b-af64-456c-ae49-a62e4364e285",
-                    "targetPort": "ac27a3bb-40ee-44de-bd3f-a737a4b80e4d",
+                    "source": "c1499a33-b3c8-4841-be1d-e137aee05400",
+                    "sourcePort": "d3722ebd-4c37-4f81-9557-5b6b3c65e7a4",
+                    "target": "c94a97a6-b7e6-4f4d-8df6-894aab284d88",
+                    "targetPort": "e09c3563-aa12-48c9-ad0d-a8f68fb12f1e",
                     "points": [
                         {
                             "id": "f1bb1e0a-ab3d-4dac-8111-b8684ead2e34",
                             "type": "point",
-                            "x": 611.3194309845983,
+                            "x": 632.1389373598931,
                             "y": 61.18055323803888
                         },
                         {
                             "id": "adfaf15c-8fd7-4221-8c98-3f06a10677df",
                             "type": "point",
-                            "x": 987.3749174117614,
+                            "x": 987.3749865081647,
                             "y": 59.77777749156739
                         }
                     ],
@@ -127,21 +127,21 @@
                     "id": "77314daf-e058-4b70-95b4-efc34e225c9d",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "91483558-f6f4-4691-8c48-c8e15d167a5e",
-                    "sourcePort": "eb426bff-7942-4c5d-9ddb-3d83924e2e71",
-                    "target": "bf87304b-af64-456c-ae49-a62e4364e285",
-                    "targetPort": "98f758b0-5df4-435b-98ed-5d8b001462ab",
+                    "source": "2335a9e8-6ea1-4222-8e3b-969b9ad56474",
+                    "sourcePort": "5f7ea288-da5f-460d-89b0-91f926b897bd",
+                    "target": "c94a97a6-b7e6-4f4d-8df6-894aab284d88",
+                    "targetPort": "7955879c-4480-4241-a7c5-a05d78b09930",
                     "points": [
                         {
                             "id": "ad7dc373-3e80-41e7-babd-2942c1501993",
                             "type": "point",
-                            "x": 907.7500802921372,
+                            "x": 907.7500489828294,
                             "y": 258.9999974265707
                         },
                         {
                             "id": "60eafb22-dbd9-4bba-aa07-636d2bb5c4f0",
                             "type": "point",
-                            "x": 987.3749174117614,
+                            "x": 987.3749865081647,
                             "y": 125.11112157323014
                         }
                     ],
@@ -155,21 +155,21 @@
                     "id": "269702f1-96a0-431d-8f19-f7c28411d70b",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "2bdec2e5-37f7-491d-a1eb-45643e1255f4",
-                    "sourcePort": "cf9e9da7-7e13-42c3-b62f-6cf83fa09cbc",
-                    "target": "bf87304b-af64-456c-ae49-a62e4364e285",
-                    "targetPort": "236e8104-ea6f-44ec-b6f1-065cc7e9c393",
+                    "source": "c1499a33-b3c8-4841-be1d-e137aee05400",
+                    "sourcePort": "04fc85c5-245a-4545-9879-5c9caeee9357",
+                    "target": "c94a97a6-b7e6-4f4d-8df6-894aab284d88",
+                    "targetPort": "9b7a773b-f3f9-4a63-bbb2-1d7bf8f91734",
                     "points": [
                         {
                             "id": "c6e81524-c108-4793-9a7e-893914863ba7",
                             "type": "point",
-                            "x": 611.3194309845983,
+                            "x": 632.1389373598931,
                             "y": 104.73611236037637
                         },
                         {
                             "id": "7ee394d5-b1fb-433c-bd51-ffe753225e8b",
                             "type": "point",
-                            "x": 987.3749174117614,
+                            "x": 987.3749865081647,
                             "y": 81.55554733605443
                         }
                     ],
@@ -183,21 +183,21 @@
                     "id": "89d8304a-a302-4e6a-ade7-16e371415882",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "6b460be5-4d71-47e0-8450-b463c3de5554",
-                    "sourcePort": "fe94a1e3-ba25-4d42-a01e-7e5d9b57290f",
-                    "target": "bf87304b-af64-456c-ae49-a62e4364e285",
-                    "targetPort": "43bf27af-e8d0-45f1-a601-14696d4f660a",
+                    "source": "764cab6d-6fb2-42cd-b756-63652a44c45f",
+                    "sourcePort": "5f0f0552-7e32-40af-a351-7ab7a860fec3",
+                    "target": "c94a97a6-b7e6-4f4d-8df6-894aab284d88",
+                    "targetPort": "991e5095-72b0-4690-b039-66af09206566",
                     "points": [
                         {
                             "id": "20905ce6-6c21-4066-ae0a-a28f554f48ad",
                             "type": "point",
-                            "x": 903.694466900333,
+                            "x": 903.6945046874285,
                             "y": 346.9166717706155
                         },
                         {
                             "id": "56c45c95-76ee-4974-bb8b-f1774e202b94",
                             "type": "point",
-                            "x": 987.3749174117614,
+                            "x": 987.3749865081647,
                             "y": 146.88889141771716
                         }
                     ],
@@ -207,25 +207,25 @@
                     "curvyness": 50,
                     "selectedColor": "rgb(0,192,255)"
                 },
-                "3f7ee79a-ea70-4fd7-9f78-8c5585b71b6c": {
-                    "id": "3f7ee79a-ea70-4fd7-9f78-8c5585b71b6c",
+                "26f0133a-0c74-472c-ad38-56a0fb56ad00": {
+                    "id": "26f0133a-0c74-472c-ad38-56a0fb56ad00",
                     "type": "triangle-link",
                     "selected": true,
-                    "source": "f95cc405-f228-40c7-b404-b0b6f500cb80",
-                    "sourcePort": "d7d6bfed-44c3-411b-933c-63326006e99f",
-                    "target": "2bdec2e5-37f7-491d-a1eb-45643e1255f4",
-                    "targetPort": "7d27ae2b-b234-4297-84d7-354d9e608544",
+                    "source": "f92f1b47-d1a3-4779-a1cf-e589353f9be2",
+                    "sourcePort": "7910864e-9948-4a08-811e-5297b4b3b6a2",
+                    "target": "c1499a33-b3c8-4841-be1d-e137aee05400",
+                    "targetPort": "24c9c7ca-90f6-4a61-8a22-a4925f3273f0",
                     "points": [
                         {
-                            "id": "ea2be9ee-edcd-4a12-831c-6ccaab1160f4",
+                            "id": "0f9e76ad-4c21-4785-9d83-6184216ad5bb",
                             "type": "point",
-                            "x": 420.76388114709,
+                            "x": 420.76391569529164,
                             "y": 174.09720454994925
                         },
                         {
-                            "id": "c6ab0720-19f8-42fb-80e4-10cb9debce18",
+                            "id": "3d541645-bbdc-4f73-b699-f7d5961361e5",
                             "type": "point",
-                            "x": 462.87499831213364,
+                            "x": 462.8750328603353,
                             "y": 82.95834251588933
                         }
                     ],
@@ -238,7 +238,7 @@
             }
         },
         {
-            "id": "ca62b12a-b921-4c85-9087-246c992e04bc",
+            "id": "f9b401da-d326-4bc3-b8ff-ed6541d26cd1",
             "type": "diagram-nodes",
             "isSvg": false,
             "transformed": true,
@@ -258,7 +258,7 @@
                             "id": "1b8ccda9-ffba-4b17-8d65-652de327b62d",
                             "type": "default",
                             "extras": {},
-                            "x": 185.62500097522422,
+                            "x": 185.62503552342588,
                             "y": 52.16666615653276,
                             "name": "out-0",
                             "alignment": "right",
@@ -280,8 +280,8 @@
                         "1b8ccda9-ffba-4b17-8d65-652de327b62d"
                     ]
                 },
-                "caf4c4c1-7665-4367-946b-4ec85864bc4b": {
-                    "id": "caf4c4c1-7665-4367-946b-4ec85864bc4b",
+                "01719176-6453-496d-bdba-ca88dacc7e0b": {
+                    "id": "01719176-6453-496d-bdba-ca88dacc7e0b",
                     "type": "custom-node",
                     "selected": true,
                     "extras": {
@@ -291,14 +291,14 @@
                     "y": 21.71445283018868,
                     "ports": [
                         {
-                            "id": "8c0d04d7-8455-44b7-9910-834bdf9915bc",
+                            "id": "e3dc3862-a6a0-4145-a82a-f883d2a70ddf",
                             "type": "default",
                             "extras": {},
                             "x": 1246.6806673409376,
                             "y": 48.59721505836059,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "caf4c4c1-7665-4367-946b-4ec85864bc4b",
+                            "parentNode": "01719176-6453-496d-bdba-ca88dacc7e0b",
                             "links": [
                                 "29614add-7959-4822-9f34-2a6c225b8a34"
                             ],
@@ -309,14 +309,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "6b5bb123-24e4-490e-b6cb-f7f1d91c6b65",
+                            "id": "243b5e71-8630-4cb6-8013-43f6ebb759b7",
                             "type": "default",
                             "extras": {},
                             "x": 1246.6806673409376,
                             "y": 70.37501945104927,
                             "name": "parameter-dynalist-outputs",
                             "alignment": "left",
-                            "parentNode": "caf4c4c1-7665-4367-946b-4ec85864bc4b",
+                            "parentNode": "01719176-6453-496d-bdba-ca88dacc7e0b",
                             "links": [],
                             "in": true,
                             "label": "outputs",
@@ -333,13 +333,13 @@
                     "name": "Finish",
                     "color": "rgb(255,102,102)",
                     "portsInOrder": [
-                        "8c0d04d7-8455-44b7-9910-834bdf9915bc",
-                        "6b5bb123-24e4-490e-b6cb-f7f1d91c6b65"
+                        "e3dc3862-a6a0-4145-a82a-f883d2a70ddf",
+                        "243b5e71-8630-4cb6-8013-43f6ebb759b7"
                     ],
                     "portsOutOrder": []
                 },
-                "bf87304b-af64-456c-ae49-a62e4364e285": {
-                    "id": "bf87304b-af64-456c-ae49-a62e4364e285",
+                "c94a97a6-b7e6-4f4d-8df6-894aab284d88": {
+                    "id": "c94a97a6-b7e6-4f4d-8df6-894aab284d88",
                     "type": "custom-node",
                     "selected": true,
                     "extras": {
@@ -357,14 +357,14 @@
                     "y": 22.501150943396226,
                     "ports": [
                         {
-                            "id": "ac27a3bb-40ee-44de-bd3f-a737a4b80e4d",
+                            "id": "e09c3563-aa12-48c9-ad0d-a8f68fb12f1e",
                             "type": "default",
                             "extras": {},
-                            "x": 976.986073443532,
+                            "x": 976.9861425399353,
                             "y": 49.388887099191955,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "bf87304b-af64-456c-ae49-a62e4364e285",
+                            "parentNode": "c94a97a6-b7e6-4f4d-8df6-894aab284d88",
                             "links": [
                                 "52f4085e-237d-43b9-ac10-769148722565"
                             ],
@@ -375,14 +375,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "236e8104-ea6f-44ec-b6f1-065cc7e9c393",
+                            "id": "9b7a773b-f3f9-4a63-bbb2-1d7bf8f91734",
                             "type": "default",
                             "extras": {},
-                            "x": 976.986073443532,
+                            "x": 976.9861425399353,
                             "y": 71.16665694367899,
                             "name": "parameter-any-gdrive",
                             "alignment": "left",
-                            "parentNode": "bf87304b-af64-456c-ae49-a62e4364e285",
+                            "parentNode": "c94a97a6-b7e6-4f4d-8df6-894aab284d88",
                             "links": [
                                 "269702f1-96a0-431d-8f19-f7c28411d70b"
                             ],
@@ -393,14 +393,14 @@
                             "dataType": "any"
                         },
                         {
-                            "id": "941557c2-d926-427f-9c39-0c4b150e1ffb",
+                            "id": "826c57e6-1607-431e-9dc1-82e91bdca8cc",
                             "type": "default",
                             "extras": {},
-                            "x": 976.986073443532,
+                            "x": 976.9861425399353,
                             "y": 92.94446133636767,
                             "name": "parameter-string-file_path",
                             "alignment": "left",
-                            "parentNode": "bf87304b-af64-456c-ae49-a62e4364e285",
+                            "parentNode": "c94a97a6-b7e6-4f4d-8df6-894aab284d88",
                             "links": [
                                 "927da9f3-873f-448f-9571-39ff0da434a1"
                             ],
@@ -411,14 +411,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "98f758b0-5df4-435b-98ed-5d8b001462ab",
+                            "id": "7955879c-4480-4241-a7c5-a05d78b09930",
                             "type": "default",
                             "extras": {},
-                            "x": 976.986073443532,
+                            "x": 976.9861425399353,
                             "y": 114.72223118085469,
                             "name": "parameter-string-folder_id",
                             "alignment": "left",
-                            "parentNode": "bf87304b-af64-456c-ae49-a62e4364e285",
+                            "parentNode": "c94a97a6-b7e6-4f4d-8df6-894aab284d88",
                             "links": [
                                 "77314daf-e058-4b70-95b4-efc34e225c9d"
                             ],
@@ -429,14 +429,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "43bf27af-e8d0-45f1-a601-14696d4f660a",
+                            "id": "991e5095-72b0-4690-b039-66af09206566",
                             "type": "default",
                             "extras": {},
-                            "x": 976.986073443532,
+                            "x": 976.9861425399353,
                             "y": 136.5000010253417,
                             "name": "parameter-string-filename",
                             "alignment": "left",
-                            "parentNode": "bf87304b-af64-456c-ae49-a62e4364e285",
+                            "parentNode": "c94a97a6-b7e6-4f4d-8df6-894aab284d88",
                             "links": [
                                 "89d8304a-a302-4e6a-ade7-16e371415882"
                             ],
@@ -447,14 +447,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "6db07717-58d9-48fd-848a-ce9964286b8d",
+                            "id": "07ebc1f4-dc20-4192-8c03-04f5abdb2250",
                             "type": "default",
                             "extras": {},
-                            "x": 976.986073443532,
+                            "x": 976.9861425399353,
                             "y": 158.27777086982874,
                             "name": "parameter-string-mimetype",
                             "alignment": "left",
-                            "parentNode": "bf87304b-af64-456c-ae49-a62e4364e285",
+                            "parentNode": "c94a97a6-b7e6-4f4d-8df6-894aab284d88",
                             "links": [],
                             "in": true,
                             "label": "mimetype",
@@ -463,14 +463,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "d7cd6c33-1f6a-46e9-bd74-b5c0a2839c15",
+                            "id": "40559040-0dad-41dc-952d-e4bc9b380730",
                             "type": "default",
                             "extras": {},
                             "x": 1130.736073443532,
                             "y": 49.388887099191955,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "bf87304b-af64-456c-ae49-a62e4364e285",
+                            "parentNode": "c94a97a6-b7e6-4f4d-8df6-894aab284d88",
                             "links": [
                                 "29614add-7959-4822-9f34-2a6c225b8a34"
                             ],
@@ -484,19 +484,19 @@
                     "name": "UploadFileToGDrive",
                     "color": "green",
                     "portsInOrder": [
-                        "ac27a3bb-40ee-44de-bd3f-a737a4b80e4d",
-                        "236e8104-ea6f-44ec-b6f1-065cc7e9c393",
-                        "941557c2-d926-427f-9c39-0c4b150e1ffb",
-                        "98f758b0-5df4-435b-98ed-5d8b001462ab",
-                        "43bf27af-e8d0-45f1-a601-14696d4f660a",
-                        "6db07717-58d9-48fd-848a-ce9964286b8d"
+                        "e09c3563-aa12-48c9-ad0d-a8f68fb12f1e",
+                        "9b7a773b-f3f9-4a63-bbb2-1d7bf8f91734",
+                        "826c57e6-1607-431e-9dc1-82e91bdca8cc",
+                        "7955879c-4480-4241-a7c5-a05d78b09930",
+                        "991e5095-72b0-4690-b039-66af09206566",
+                        "07ebc1f4-dc20-4192-8c03-04f5abdb2250"
                     ],
                     "portsOutOrder": [
-                        "d7cd6c33-1f6a-46e9-bd74-b5c0a2839c15"
+                        "40559040-0dad-41dc-952d-e4bc9b380730"
                     ]
                 },
-                "30a0462e-c687-4969-a875-a69af2e80032": {
-                    "id": "30a0462e-c687-4969-a875-a69af2e80032",
+                "29c3573a-139f-46c2-96a7-2924e65639dd": {
+                    "id": "29c3573a-139f-46c2-96a7-2924e65639dd",
                     "type": "custom-node",
                     "selected": true,
                     "extras": {
@@ -507,14 +507,14 @@
                     "y": 144.06684905660376,
                     "ports": [
                         {
-                            "id": "4c5c3d12-8512-4e45-8f37-a295dbea9802",
+                            "id": "8b52d561-7053-46c2-b6d2-82fe56c86bc5",
                             "type": "default",
                             "extras": {},
                             "x": 895.2778491289683,
                             "y": 168.3888894024054,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "30a0462e-c687-4969-a875-a69af2e80032",
+                            "parentNode": "29c3573a-139f-46c2-96a7-2924e65639dd",
                             "links": [
                                 "927da9f3-873f-448f-9571-39ff0da434a1"
                             ],
@@ -529,11 +529,11 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "4c5c3d12-8512-4e45-8f37-a295dbea9802"
+                        "8b52d561-7053-46c2-b6d2-82fe56c86bc5"
                     ]
                 },
-                "2bdec2e5-37f7-491d-a1eb-45643e1255f4": {
-                    "id": "2bdec2e5-37f7-491d-a1eb-45643e1255f4",
+                "c1499a33-b3c8-4841-be1d-e137aee05400": {
+                    "id": "c1499a33-b3c8-4841-be1d-e137aee05400",
                     "type": "custom-node",
                     "selected": true,
                     "extras": {
@@ -552,14 +552,14 @@
                     "y": 23.912283141349985,
                     "ports": [
                         {
-                            "id": "f4cf8ea6-4f2b-4c53-a863-5d50780048b0",
+                            "id": "e88238e6-f849-4b1a-83c6-92176b066387",
                             "type": "default",
                             "extras": {},
-                            "x": 452.4861241142277,
+                            "x": 452.4861586624294,
                             "y": 50.79164773082521,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "2bdec2e5-37f7-491d-a1eb-45643e1255f4",
+                            "parentNode": "c1499a33-b3c8-4841-be1d-e137aee05400",
                             "links": [
                                 "a617ca34-5835-422e-ab32-361f84f4fc6d"
                             ],
@@ -570,32 +570,32 @@
                             "dataType": ""
                         },
                         {
-                            "id": "7d27ae2b-b234-4297-84d7-354d9e608544",
+                            "id": "24c9c7ca-90f6-4a61-8a22-a4925f3273f0",
                             "type": "default",
                             "extras": {},
-                            "x": 452.4861241142277,
+                            "x": 452.4861586624294,
                             "y": 72.56945212351388,
-                            "name": "parameter-string-json_path",
+                            "name": "parameter-string-service_json_path",
                             "alignment": "left",
-                            "parentNode": "2bdec2e5-37f7-491d-a1eb-45643e1255f4",
+                            "parentNode": "c1499a33-b3c8-4841-be1d-e137aee05400",
                             "links": [
-                                "3f7ee79a-ea70-4fd7-9f78-8c5585b71b6c"
+                                "26f0133a-0c74-472c-ad38-56a0fb56ad00"
                             ],
                             "in": true,
-                            "label": "json_path",
-                            "varName": "json_path",
+                            "label": "service_json_path",
+                            "varName": "service_json_path",
                             "portType": "",
                             "dataType": "string"
                         },
                         {
-                            "id": "1ea85e57-ff38-4a9e-947e-6262ab4aac58",
+                            "id": "d3722ebd-4c37-4f81-9557-5b6b3c65e7a4",
                             "type": "default",
                             "extras": {},
-                            "x": 600.9305567866924,
+                            "x": 621.7500631619872,
                             "y": 50.79164773082521,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "2bdec2e5-37f7-491d-a1eb-45643e1255f4",
+                            "parentNode": "c1499a33-b3c8-4841-be1d-e137aee05400",
                             "links": [
                                 "52f4085e-237d-43b9-ac10-769148722565"
                             ],
@@ -606,14 +606,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "306bf460-3031-4d09-a49b-95984067ffa8",
+                            "id": "a4dbe5e5-0620-4c2d-90ac-9ac077c568ab",
                             "type": "default",
                             "extras": {},
-                            "x": 600.9305567866924,
+                            "x": 621.7500631619872,
                             "y": 72.56945212351388,
                             "name": "parameter-out-any-gauth",
                             "alignment": "right",
-                            "parentNode": "2bdec2e5-37f7-491d-a1eb-45643e1255f4",
+                            "parentNode": "c1499a33-b3c8-4841-be1d-e137aee05400",
                             "links": [],
                             "in": false,
                             "label": "gauth",
@@ -622,14 +622,14 @@
                             "dataType": "any"
                         },
                         {
-                            "id": "cf9e9da7-7e13-42c3-b62f-6cf83fa09cbc",
+                            "id": "04fc85c5-245a-4545-9879-5c9caeee9357",
                             "type": "default",
                             "extras": {},
-                            "x": 600.9305567866924,
+                            "x": 621.7500631619872,
                             "y": 94.34722196800092,
                             "name": "parameter-out-any-gdrive",
                             "alignment": "right",
-                            "parentNode": "2bdec2e5-37f7-491d-a1eb-45643e1255f4",
+                            "parentNode": "c1499a33-b3c8-4841-be1d-e137aee05400",
                             "links": [
                                 "269702f1-96a0-431d-8f19-f7c28411d70b"
                             ],
@@ -643,17 +643,17 @@
                     "name": "GDriveServiceAuth",
                     "color": "rgb(15,255,255)",
                     "portsInOrder": [
-                        "f4cf8ea6-4f2b-4c53-a863-5d50780048b0",
-                        "7d27ae2b-b234-4297-84d7-354d9e608544"
+                        "e88238e6-f849-4b1a-83c6-92176b066387",
+                        "24c9c7ca-90f6-4a61-8a22-a4925f3273f0"
                     ],
                     "portsOutOrder": [
-                        "1ea85e57-ff38-4a9e-947e-6262ab4aac58",
-                        "306bf460-3031-4d09-a49b-95984067ffa8",
-                        "cf9e9da7-7e13-42c3-b62f-6cf83fa09cbc"
+                        "d3722ebd-4c37-4f81-9557-5b6b3c65e7a4",
+                        "a4dbe5e5-0620-4c2d-90ac-9ac077c568ab",
+                        "04fc85c5-245a-4545-9879-5c9caeee9357"
                     ]
                 },
-                "91483558-f6f4-4691-8c48-c8e15d167a5e": {
-                    "id": "91483558-f6f4-4691-8c48-c8e15d167a5e",
+                "2335a9e8-6ea1-4222-8e3b-969b9ad56474": {
+                    "id": "2335a9e8-6ea1-4222-8e3b-969b9ad56474",
                     "type": "custom-node",
                     "selected": true,
                     "extras": {
@@ -663,14 +663,14 @@
                     "y": 224.289641631916,
                     "ports": [
                         {
-                            "id": "eb426bff-7942-4c5d-9ddb-3d83924e2e71",
+                            "id": "5f7ea288-da5f-460d-89b0-91f926b897bd",
                             "type": "default",
                             "extras": {},
                             "x": 897.3611747849235,
                             "y": 248.61109191935702,
                             "name": "parameter-out-0",
                             "alignment": "right",
-                            "parentNode": "91483558-f6f4-4691-8c48-c8e15d167a5e",
+                            "parentNode": "2335a9e8-6ea1-4222-8e3b-969b9ad56474",
                             "links": [
                                 "77314daf-e058-4b70-95b4-efc34e225c9d"
                             ],
@@ -685,11 +685,11 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "eb426bff-7942-4c5d-9ddb-3d83924e2e71"
+                        "5f7ea288-da5f-460d-89b0-91f926b897bd"
                     ]
                 },
-                "f95cc405-f228-40c7-b404-b0b6f500cb80": {
-                    "id": "f95cc405-f228-40c7-b404-b0b6f500cb80",
+                "f92f1b47-d1a3-4779-a1cf-e589353f9be2": {
+                    "id": "f92f1b47-d1a3-4779-a1cf-e589353f9be2",
                     "type": "custom-node",
                     "selected": true,
                     "extras": {
@@ -700,16 +700,16 @@
                     "y": 139.3839812545575,
                     "ports": [
                         {
-                            "id": "d7d6bfed-44c3-411b-933c-63326006e99f",
+                            "id": "7910864e-9948-4a08-811e-5297b4b3b6a2",
                             "type": "default",
                             "extras": {},
-                            "x": 410.3749756398763,
+                            "x": 410.37501018807797,
                             "y": 163.70829904273558,
                             "name": "parameter-out-0",
                             "alignment": "right",
-                            "parentNode": "f95cc405-f228-40c7-b404-b0b6f500cb80",
+                            "parentNode": "f92f1b47-d1a3-4779-a1cf-e589353f9be2",
                             "links": [
-                                "3f7ee79a-ea70-4fd7-9f78-8c5585b71b6c"
+                                "26f0133a-0c74-472c-ad38-56a0fb56ad00"
                             ],
                             "in": false,
                             "label": "▶",
@@ -722,11 +722,11 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "d7d6bfed-44c3-411b-933c-63326006e99f"
+                        "7910864e-9948-4a08-811e-5297b4b3b6a2"
                     ]
                 },
-                "6b460be5-4d71-47e0-8450-b463c3de5554": {
-                    "id": "6b460be5-4d71-47e0-8450-b463c3de5554",
+                "764cab6d-6fb2-42cd-b756-63652a44c45f": {
+                    "id": "764cab6d-6fb2-42cd-b756-63652a44c45f",
                     "type": "custom-node",
                     "selected": true,
                     "extras": {
@@ -737,14 +737,14 @@
                     "y": 312.1959622641509,
                     "ports": [
                         {
-                            "id": "fe94a1e3-ba25-4d42-a01e-7e5d9b57290f",
+                            "id": "5f0f0552-7e32-40af-a351-7ab7a860fec3",
                             "type": "default",
                             "extras": {},
-                            "x": 893.3055613931193,
+                            "x": 893.3056304895226,
                             "y": 336.5277662634018,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "6b460be5-4d71-47e0-8450-b463c3de5554",
+                            "parentNode": "764cab6d-6fb2-42cd-b756-63652a44c45f",
                             "links": [
                                 "89d8304a-a302-4e6a-ade7-16e371415882"
                             ],
@@ -759,7 +759,7 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "fe94a1e3-ba25-4d42-a01e-7e5d9b57290f"
+                        "5f0f0552-7e32-40af-a351-7ab7a860fec3"
                     ]
                 }
             }

--- a/examples/GDriveSimpleUpload.xircuits
+++ b/examples/GDriveSimpleUpload.xircuits
@@ -6,7 +6,7 @@
     "gridSize": 0,
     "layers": [
         {
-            "id": "a1a949b0-aa89-4a7b-84f8-110214c2f3ae",
+            "id": "4074301d-1a9d-4863-91e6-2dbd7f604ef1",
             "type": "diagram-links",
             "isSvg": true,
             "transformed": true,
@@ -15,22 +15,22 @@
                     "id": "29614add-7959-4822-9f34-2a6c225b8a34",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "c18af0b1-0c4a-4c93-9d3c-ea3ced373f6c",
-                    "sourcePort": "02bb04c3-7d3c-4310-b55c-26a36c1c52f3",
-                    "target": "17c02af9-7f4d-42b5-a707-26510fcfa0cc",
-                    "targetPort": "bae26971-ea6b-4233-83b6-ef81a9ea8999",
+                    "source": "bf87304b-af64-456c-ae49-a62e4364e285",
+                    "sourcePort": "d7cd6c33-1f6a-46e9-bd74-b5c0a2839c15",
+                    "target": "caf4c4c1-7665-4367-946b-4ec85864bc4b",
+                    "targetPort": "8c0d04d7-8455-44b7-9910-834bdf9915bc",
                     "points": [
                         {
                             "id": "35e75aa2-8131-432e-b8fe-2173c0c32ee4",
                             "type": "point",
-                            "x": 1141.250072590767,
-                            "y": 59.600002162553366
+                            "x": 1141.1249789507456,
+                            "y": 59.77777749156739
                         },
                         {
                             "id": "910a6f32-88a1-4415-93bd-145228065222",
                             "type": "point",
-                            "x": 1256.8964464115218,
-                            "y": 58.808730664934885
+                            "x": 1257.069511309167,
+                            "y": 58.986120565574254
                         }
                     ],
                     "labels": [],
@@ -43,22 +43,22 @@
                     "id": "927da9f3-873f-448f-9571-39ff0da434a1",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "37cb3850-45a3-4649-a722-eeefbbbce9c3",
-                    "sourcePort": "49cf8a77-8f60-4c67-b186-178b6a4c969a",
-                    "target": "c18af0b1-0c4a-4c93-9d3c-ea3ced373f6c",
-                    "targetPort": "c91769a0-dab8-4af1-aa4f-66f955630189",
+                    "source": "30a0462e-c687-4969-a875-a69af2e80032",
+                    "sourcePort": "4c5c3d12-8512-4e45-8f37-a295dbea9802",
+                    "target": "bf87304b-af64-456c-ae49-a62e4364e285",
+                    "targetPort": "941557c2-d926-427f-9c39-0c4b150e1ffb",
                     "points": [
                         {
                             "id": "4b290c64-c640-49c6-86fb-506640f17e04",
                             "type": "point",
-                            "x": 905.8000707481965,
-                            "y": 178.16248604005926
+                            "x": 905.6667546361821,
+                            "y": 178.77779490961905
                         },
                         {
                             "id": "d7bb9686-ed83-4343-8486-bd1490459985",
                             "type": "point",
-                            "x": 987.2000560076305,
-                            "y": 102.79999227313063
+                            "x": 987.3749174117614,
+                            "y": 103.33335172874311
                         }
                     ],
                     "labels": [],
@@ -73,20 +73,20 @@
                     "selected": false,
                     "source": "e705a570-8daf-4330-8c6b-9d8fceda6bd7",
                     "sourcePort": "1b8ccda9-ffba-4b17-8d65-652de327b62d",
-                    "target": "3f7f910d-0199-4861-add9-70d855fef92c",
-                    "targetPort": "21a698b1-48ae-41f3-8b33-9b4820f501c3",
+                    "target": "2bdec2e5-37f7-491d-a1eb-45643e1255f4",
+                    "targetPort": "f4cf8ea6-4f2b-4c53-a863-5d50780048b0",
                     "points": [
                         {
                             "id": "cda35395-1baf-4a71-a98b-2df219d99447",
                             "type": "point",
-                            "x": 196.05003850320827,
-                            "y": 62.37498281556043
+                            "x": 196.01387517313015,
+                            "y": 62.5555565489082
                         },
                         {
                             "id": "f04339b9-3ce7-447e-8fe6-737323970cff",
                             "type": "point",
-                            "x": 462.6999684855196,
-                            "y": 60.999984902847615
+                            "x": 462.87499831213364,
+                            "y": 61.18055323803888
                         }
                     ],
                     "labels": [],
@@ -99,22 +99,22 @@
                     "id": "52f4085e-237d-43b9-ac10-769148722565",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "3f7f910d-0199-4861-add9-70d855fef92c",
-                    "sourcePort": "8d8deb69-7834-47a8-b61e-4c0e29899fb9",
-                    "target": "c18af0b1-0c4a-4c93-9d3c-ea3ced373f6c",
-                    "targetPort": "79e3c11e-2e0c-4998-affb-0e57df4cb34b",
+                    "source": "2bdec2e5-37f7-491d-a1eb-45643e1255f4",
+                    "sourcePort": "1ea85e57-ff38-4a9e-947e-6262ab4aac58",
+                    "target": "bf87304b-af64-456c-ae49-a62e4364e285",
+                    "targetPort": "ac27a3bb-40ee-44de-bd3f-a737a4b80e4d",
                     "points": [
                         {
                             "id": "f1bb1e0a-ab3d-4dac-8111-b8684ead2e34",
                             "type": "point",
-                            "x": 640.7375755705496,
-                            "y": 60.999984902847615
+                            "x": 611.3194309845983,
+                            "y": 61.18055323803888
                         },
                         {
                             "id": "adfaf15c-8fd7-4221-8c98-3f06a10677df",
                             "type": "point",
-                            "x": 987.2000560076305,
-                            "y": 59.600002162553366
+                            "x": 987.3749174117614,
+                            "y": 59.77777749156739
                         }
                     ],
                     "labels": [],
@@ -127,50 +127,22 @@
                     "id": "77314daf-e058-4b70-95b4-efc34e225c9d",
                     "type": "triangle-link",
                     "selected": false,
-                    "source": "09859332-f868-4bb1-97ae-8e5bc811047b",
-                    "sourcePort": "42966bfc-57c6-44c9-bd20-e571e6abdc17",
-                    "target": "c18af0b1-0c4a-4c93-9d3c-ea3ced373f6c",
-                    "targetPort": "7f447975-2dcc-49d3-91e0-3d67b8cfc462",
+                    "source": "91483558-f6f4-4691-8c48-c8e15d167a5e",
+                    "sourcePort": "eb426bff-7942-4c5d-9ddb-3d83924e2e71",
+                    "target": "bf87304b-af64-456c-ae49-a62e4364e285",
+                    "targetPort": "98f758b0-5df4-435b-98ed-5d8b001462ab",
                     "points": [
                         {
                             "id": "ad7dc373-3e80-41e7-babd-2942c1501993",
                             "type": "point",
-                            "x": 907.9250615353427,
-                            "y": 258.3875215095463
+                            "x": 907.7500802921372,
+                            "y": 258.9999974265707
                         },
                         {
                             "id": "60eafb22-dbd9-4bba-aa07-636d2bb5c4f0",
                             "type": "point",
-                            "x": 987.2000560076305,
-                            "y": 124.40001162012354
-                        }
-                    ],
-                    "labels": [],
-                    "width": 3,
-                    "color": "gray",
-                    "curvyness": 50,
-                    "selectedColor": "rgb(0,192,255)"
-                },
-                "3479534e-4629-457e-b1c4-2c040d4a24c4": {
-                    "id": "3479534e-4629-457e-b1c4-2c040d4a24c4",
-                    "type": "triangle-link",
-                    "selected": false,
-                    "source": "83598400-386b-4338-9768-22d9151bf20d",
-                    "sourcePort": "efad80e2-824f-466d-ae41-cd2574d0052b",
-                    "target": "3f7f910d-0199-4861-add9-70d855fef92c",
-                    "targetPort": "b2773a85-6773-4dd2-8f19-06848eb3aa63",
-                    "points": [
-                        {
-                            "id": "ccb4d7b8-6954-4041-8e39-b8e148db4a07",
-                            "type": "point",
-                            "x": 420.96249336022476,
-                            "y": 173.47498604005926
-                        },
-                        {
-                            "id": "acb18565-8fd6-4a80-8340-5c620e907903",
-                            "type": "point",
-                            "x": 462.6999684855196,
-                            "y": 82.60000424984054
+                            "x": 987.3749174117614,
+                            "y": 125.11112157323014
                         }
                     ],
                     "labels": [],
@@ -183,22 +155,22 @@
                     "id": "269702f1-96a0-431d-8f19-f7c28411d70b",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "3f7f910d-0199-4861-add9-70d855fef92c",
-                    "sourcePort": "35b3e990-2e53-4fe2-a4aa-4976176e0d32",
-                    "target": "c18af0b1-0c4a-4c93-9d3c-ea3ced373f6c",
-                    "targetPort": "c6966e82-2895-45d4-8db0-9e7a240633e1",
+                    "source": "2bdec2e5-37f7-491d-a1eb-45643e1255f4",
+                    "sourcePort": "cf9e9da7-7e13-42c3-b62f-6cf83fa09cbc",
+                    "target": "bf87304b-af64-456c-ae49-a62e4364e285",
+                    "targetPort": "236e8104-ea6f-44ec-b6f1-065cc7e9c393",
                     "points": [
                         {
                             "id": "c6e81524-c108-4793-9a7e-893914863ba7",
                             "type": "point",
-                            "x": 640.7375755705496,
-                            "y": 104.1999890486318
+                            "x": 611.3194309845983,
+                            "y": 104.73611236037637
                         },
                         {
                             "id": "7ee394d5-b1fb-433c-bd51-ffe753225e8b",
                             "type": "point",
-                            "x": 987.2000560076305,
-                            "y": 81.20002150954627
+                            "x": 987.3749174117614,
+                            "y": 81.55554733605443
                         }
                     ],
                     "labels": [],
@@ -211,22 +183,50 @@
                     "id": "89d8304a-a302-4e6a-ade7-16e371415882",
                     "type": "parameter-link",
                     "selected": false,
-                    "source": "106c857b-4c16-4808-829d-ea7cd94d6a6d",
-                    "sourcePort": "ead1a4b1-040d-4881-913d-eedcfc9fed96",
-                    "target": "c18af0b1-0c4a-4c93-9d3c-ea3ced373f6c",
-                    "targetPort": "b908ce2c-3237-4285-9355-7279fb5722c4",
+                    "source": "6b460be5-4d71-47e0-8450-b463c3de5554",
+                    "sourcePort": "fe94a1e3-ba25-4d42-a01e-7e5d9b57290f",
+                    "target": "bf87304b-af64-456c-ae49-a62e4364e285",
+                    "targetPort": "43bf27af-e8d0-45f1-a601-14696d4f660a",
                     "points": [
                         {
                             "id": "20905ce6-6c21-4066-ae0a-a28f554f48ad",
                             "type": "point",
-                            "x": 903.7625560076305,
-                            "y": 346.28748100177984
+                            "x": 903.694466900333,
+                            "y": 346.9166717706155
                         },
                         {
                             "id": "56c45c95-76ee-4974-bb8b-f1774e202b94",
                             "type": "point",
-                            "x": 987.2000560076305,
-                            "y": 146.00001045412176
+                            "x": 987.3749174117614,
+                            "y": 146.88889141771716
+                        }
+                    ],
+                    "labels": [],
+                    "width": 3,
+                    "color": "gray",
+                    "curvyness": 50,
+                    "selectedColor": "rgb(0,192,255)"
+                },
+                "3f7ee79a-ea70-4fd7-9f78-8c5585b71b6c": {
+                    "id": "3f7ee79a-ea70-4fd7-9f78-8c5585b71b6c",
+                    "type": "triangle-link",
+                    "selected": true,
+                    "source": "f95cc405-f228-40c7-b404-b0b6f500cb80",
+                    "sourcePort": "d7d6bfed-44c3-411b-933c-63326006e99f",
+                    "target": "2bdec2e5-37f7-491d-a1eb-45643e1255f4",
+                    "targetPort": "7d27ae2b-b234-4297-84d7-354d9e608544",
+                    "points": [
+                        {
+                            "id": "ea2be9ee-edcd-4a12-831c-6ccaab1160f4",
+                            "type": "point",
+                            "x": 420.76388114709,
+                            "y": 174.09720454994925
+                        },
+                        {
+                            "id": "c6ab0720-19f8-42fb-80e4-10cb9debce18",
+                            "type": "point",
+                            "x": 462.87499831213364,
+                            "y": 82.95834251588933
                         }
                     ],
                     "labels": [],
@@ -238,7 +238,7 @@
             }
         },
         {
-            "id": "716ac19e-0539-446a-9bfd-e41169a94f67",
+            "id": "ca62b12a-b921-4c85-9087-246c992e04bc",
             "type": "diagram-nodes",
             "isSvg": false,
             "transformed": true,
@@ -258,8 +258,8 @@
                             "id": "1b8ccda9-ffba-4b17-8d65-652de327b62d",
                             "type": "default",
                             "extras": {},
-                            "x": 185.750030916999,
-                            "y": 52.07497522935115,
+                            "x": 185.62500097522422,
+                            "y": 52.16666615653276,
                             "name": "out-0",
                             "alignment": "right",
                             "parentNode": "e705a570-8daf-4330-8c6b-9d8fceda6bd7",
@@ -280,8 +280,8 @@
                         "1b8ccda9-ffba-4b17-8d65-652de327b62d"
                     ]
                 },
-                "17c02af9-7f4d-42b5-a707-26510fcfa0cc": {
-                    "id": "17c02af9-7f4d-42b5-a707-26510fcfa0cc",
+                "caf4c4c1-7665-4367-946b-4ec85864bc4b": {
+                    "id": "caf4c4c1-7665-4367-946b-4ec85864bc4b",
                     "type": "custom-node",
                     "selected": true,
                     "extras": {
@@ -291,14 +291,14 @@
                     "y": 21.71445283018868,
                     "ports": [
                         {
-                            "id": "bae26971-ea6b-4233-83b6-ef81a9ea8999",
+                            "id": "8c0d04d7-8455-44b7-9910-834bdf9915bc",
                             "type": "default",
                             "extras": {},
-                            "x": 1246.5964388253205,
-                            "y": 48.508737113932526,
+                            "x": 1246.6806673409376,
+                            "y": 48.59721505836059,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "17c02af9-7f4d-42b5-a707-26510fcfa0cc",
+                            "parentNode": "caf4c4c1-7665-4367-946b-4ec85864bc4b",
                             "links": [
                                 "29614add-7959-4822-9f34-2a6c225b8a34"
                             ],
@@ -309,14 +309,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "4d2a6633-2380-4351-bd09-670836bc3ab2",
+                            "id": "6b5bb123-24e4-490e-b6cb-f7f1d91c6b65",
                             "type": "default",
                             "extras": {},
-                            "x": 1246.5964388253205,
-                            "y": 70.10872191272375,
+                            "x": 1246.6806673409376,
+                            "y": 70.37501945104927,
                             "name": "parameter-dynalist-outputs",
                             "alignment": "left",
-                            "parentNode": "17c02af9-7f4d-42b5-a707-26510fcfa0cc",
+                            "parentNode": "caf4c4c1-7665-4367-946b-4ec85864bc4b",
                             "links": [],
                             "in": true,
                             "label": "outputs",
@@ -333,40 +333,38 @@
                     "name": "Finish",
                     "color": "rgb(255,102,102)",
                     "portsInOrder": [
-                        "bae26971-ea6b-4233-83b6-ef81a9ea8999",
-                        "4d2a6633-2380-4351-bd09-670836bc3ab2"
+                        "8c0d04d7-8455-44b7-9910-834bdf9915bc",
+                        "6b5bb123-24e4-490e-b6cb-f7f1d91c6b65"
                     ],
                     "portsOutOrder": []
                 },
-                "c18af0b1-0c4a-4c93-9d3c-ea3ced373f6c": {
-                    "id": "c18af0b1-0c4a-4c93-9d3c-ea3ced373f6c",
+                "bf87304b-af64-456c-ae49-a62e4364e285": {
+                    "id": "bf87304b-af64-456c-ae49-a62e4364e285",
                     "type": "custom-node",
-                    "selected": false,
+                    "selected": true,
                     "extras": {
                         "type": "library_component",
                         "path": "xai_components/xai_gdrive/gdrive_components.py",
                         "description": "A component that uploads a file to a specific folder on Google Drive.\n\n##### inPorts:\n- file_path: the path to the file to upload.\n- folder_id: the ID of the folder to upload the file to.\n- filename: the name to give the uploaded file.",
                         "lineNo": [
                             {
-                                "lineno": 116,
-                                "end_lineno": 161
+                                "lineno": 122,
+                                "end_lineno": 167
                             }
-                        ],
-                        "nextNode": "None",
-                        "borderColor": "rgb(0,192,255)"
+                        ]
                     },
                     "x": 976.1056981132075,
                     "y": 22.501150943396226,
                     "ports": [
                         {
-                            "id": "79e3c11e-2e0c-4998-affb-0e57df4cb34b",
+                            "id": "ac27a3bb-40ee-44de-bd3f-a737a4b80e4d",
                             "type": "default",
                             "extras": {},
-                            "x": 976.9000484214212,
-                            "y": 49.29999457634408,
+                            "x": 976.986073443532,
+                            "y": 49.388887099191955,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "c18af0b1-0c4a-4c93-9d3c-ea3ced373f6c",
+                            "parentNode": "bf87304b-af64-456c-ae49-a62e4364e285",
                             "links": [
                                 "52f4085e-237d-43b9-ac10-769148722565"
                             ],
@@ -377,14 +375,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "c6966e82-2895-45d4-8db0-9e7a240633e1",
+                            "id": "236e8104-ea6f-44ec-b6f1-065cc7e9c393",
                             "type": "default",
                             "extras": {},
-                            "x": 976.9000484214212,
-                            "y": 70.900013923337,
+                            "x": 976.986073443532,
+                            "y": 71.16665694367899,
                             "name": "parameter-any-gdrive",
                             "alignment": "left",
-                            "parentNode": "c18af0b1-0c4a-4c93-9d3c-ea3ced373f6c",
+                            "parentNode": "bf87304b-af64-456c-ae49-a62e4364e285",
                             "links": [
                                 "269702f1-96a0-431d-8f19-f7c28411d70b"
                             ],
@@ -395,14 +393,14 @@
                             "dataType": "any"
                         },
                         {
-                            "id": "c91769a0-dab8-4af1-aa4f-66f955630189",
+                            "id": "941557c2-d926-427f-9c39-0c4b150e1ffb",
                             "type": "default",
                             "extras": {},
-                            "x": 976.9000484214212,
-                            "y": 92.49999872212827,
+                            "x": 976.986073443532,
+                            "y": 92.94446133636767,
                             "name": "parameter-string-file_path",
                             "alignment": "left",
-                            "parentNode": "c18af0b1-0c4a-4c93-9d3c-ea3ced373f6c",
+                            "parentNode": "bf87304b-af64-456c-ae49-a62e4364e285",
                             "links": [
                                 "927da9f3-873f-448f-9571-39ff0da434a1"
                             ],
@@ -413,14 +411,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "7f447975-2dcc-49d3-91e0-3d67b8cfc462",
+                            "id": "98f758b0-5df4-435b-98ed-5d8b001462ab",
                             "type": "default",
                             "extras": {},
-                            "x": 976.9000484214212,
-                            "y": 114.10001806912119,
+                            "x": 976.986073443532,
+                            "y": 114.72223118085469,
                             "name": "parameter-string-folder_id",
                             "alignment": "left",
-                            "parentNode": "c18af0b1-0c4a-4c93-9d3c-ea3ced373f6c",
+                            "parentNode": "bf87304b-af64-456c-ae49-a62e4364e285",
                             "links": [
                                 "77314daf-e058-4b70-95b4-efc34e225c9d"
                             ],
@@ -431,14 +429,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "b908ce2c-3237-4285-9355-7279fb5722c4",
+                            "id": "43bf27af-e8d0-45f1-a601-14696d4f660a",
                             "type": "default",
                             "extras": {},
-                            "x": 976.9000484214212,
-                            "y": 135.70000286791247,
+                            "x": 976.986073443532,
+                            "y": 136.5000010253417,
                             "name": "parameter-string-filename",
                             "alignment": "left",
-                            "parentNode": "c18af0b1-0c4a-4c93-9d3c-ea3ced373f6c",
+                            "parentNode": "bf87304b-af64-456c-ae49-a62e4364e285",
                             "links": [
                                 "89d8304a-a302-4e6a-ade7-16e371415882"
                             ],
@@ -449,14 +447,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "4204934e-17da-4866-ba64-18f83edec3ae",
+                            "id": "6db07717-58d9-48fd-848a-ce9964286b8d",
                             "type": "default",
                             "extras": {},
-                            "x": 976.9000484214212,
-                            "y": 157.2999531185021,
+                            "x": 976.986073443532,
+                            "y": 158.27777086982874,
                             "name": "parameter-string-mimetype",
                             "alignment": "left",
-                            "parentNode": "c18af0b1-0c4a-4c93-9d3c-ea3ced373f6c",
+                            "parentNode": "bf87304b-af64-456c-ae49-a62e4364e285",
                             "links": [],
                             "in": true,
                             "label": "mimetype",
@@ -465,14 +463,14 @@
                             "dataType": "string"
                         },
                         {
-                            "id": "02bb04c3-7d3c-4310-b55c-26a36c1c52f3",
+                            "id": "d7cd6c33-1f6a-46e9-bd74-b5c0a2839c15",
                             "type": "default",
                             "extras": {},
-                            "x": 1130.950065004558,
-                            "y": 49.29999457634408,
+                            "x": 1130.736073443532,
+                            "y": 49.388887099191955,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "c18af0b1-0c4a-4c93-9d3c-ea3ced373f6c",
+                            "parentNode": "bf87304b-af64-456c-ae49-a62e4364e285",
                             "links": [
                                 "29614add-7959-4822-9f34-2a6c225b8a34"
                             ],
@@ -486,21 +484,21 @@
                     "name": "UploadFileToGDrive",
                     "color": "green",
                     "portsInOrder": [
-                        "79e3c11e-2e0c-4998-affb-0e57df4cb34b",
-                        "c6966e82-2895-45d4-8db0-9e7a240633e1",
-                        "c91769a0-dab8-4af1-aa4f-66f955630189",
-                        "7f447975-2dcc-49d3-91e0-3d67b8cfc462",
-                        "b908ce2c-3237-4285-9355-7279fb5722c4",
-                        "4204934e-17da-4866-ba64-18f83edec3ae"
+                        "ac27a3bb-40ee-44de-bd3f-a737a4b80e4d",
+                        "236e8104-ea6f-44ec-b6f1-065cc7e9c393",
+                        "941557c2-d926-427f-9c39-0c4b150e1ffb",
+                        "98f758b0-5df4-435b-98ed-5d8b001462ab",
+                        "43bf27af-e8d0-45f1-a601-14696d4f660a",
+                        "6db07717-58d9-48fd-848a-ce9964286b8d"
                     ],
                     "portsOutOrder": [
-                        "02bb04c3-7d3c-4310-b55c-26a36c1c52f3"
+                        "d7cd6c33-1f6a-46e9-bd74-b5c0a2839c15"
                     ]
                 },
-                "37cb3850-45a3-4649-a722-eeefbbbce9c3": {
-                    "id": "37cb3850-45a3-4649-a722-eeefbbbce9c3",
+                "30a0462e-c687-4969-a875-a69af2e80032": {
+                    "id": "30a0462e-c687-4969-a875-a69af2e80032",
                     "type": "custom-node",
-                    "selected": false,
+                    "selected": true,
                     "extras": {
                         "type": "string",
                         "attached": false
@@ -509,14 +507,14 @@
                     "y": 144.06684905660376,
                     "ports": [
                         {
-                            "id": "49cf8a77-8f60-4c67-b186-178b6a4c969a",
+                            "id": "4c5c3d12-8512-4e45-8f37-a295dbea9802",
                             "type": "default",
                             "extras": {},
-                            "x": 895.5000631619872,
-                            "y": 167.86247845384997,
+                            "x": 895.2778491289683,
+                            "y": 168.3888894024054,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "37cb3850-45a3-4649-a722-eeefbbbce9c3",
+                            "parentNode": "30a0462e-c687-4969-a875-a69af2e80032",
                             "links": [
                                 "927da9f3-873f-448f-9571-39ff0da434a1"
                             ],
@@ -531,21 +529,21 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "49cf8a77-8f60-4c67-b186-178b6a4c969a"
+                        "4c5c3d12-8512-4e45-8f37-a295dbea9802"
                     ]
                 },
-                "3f7f910d-0199-4861-add9-70d855fef92c": {
-                    "id": "3f7f910d-0199-4861-add9-70d855fef92c",
+                "2bdec2e5-37f7-491d-a1eb-45643e1255f4": {
+                    "id": "2bdec2e5-37f7-491d-a1eb-45643e1255f4",
                     "type": "custom-node",
-                    "selected": false,
+                    "selected": true,
                     "extras": {
                         "type": "library_component",
                         "path": "xai_components/xai_gdrive/gdrive_components.py",
                         "description": "A component that authenticates with Google Drive using a service account.\n\n##### inPorts:\n- json_path: the path to the service account's secrets JSON file.",
                         "lineNo": [
                             {
-                                "lineno": 25,
-                                "end_lineno": 57
+                                "lineno": 18,
+                                "end_lineno": 64
                             }
                         ],
                         "borderColor": "rgb(0,192,255)"
@@ -554,14 +552,14 @@
                     "y": 23.912283141349985,
                     "ports": [
                         {
-                            "id": "21a698b1-48ae-41f3-8b33-9b4820f501c3",
+                            "id": "f4cf8ea6-4f2b-4c53-a863-5d50780048b0",
                             "type": "default",
                             "extras": {},
-                            "x": 452.3999608993103,
-                            "y": 50.69999135184526,
+                            "x": 452.4861241142277,
+                            "y": 50.79164773082521,
                             "name": "in-0",
                             "alignment": "left",
-                            "parentNode": "3f7f910d-0199-4861-add9-70d855fef92c",
+                            "parentNode": "2bdec2e5-37f7-491d-a1eb-45643e1255f4",
                             "links": [
                                 "a617ca34-5835-422e-ab32-361f84f4fc6d"
                             ],
@@ -572,32 +570,32 @@
                             "dataType": ""
                         },
                         {
-                            "id": "b2773a85-6773-4dd2-8f19-06848eb3aa63",
+                            "id": "7d27ae2b-b234-4297-84d7-354d9e608544",
                             "type": "default",
                             "extras": {},
-                            "x": 452.3999608993103,
-                            "y": 72.30001069883818,
-                            "name": "parameter-string-service_json_path",
+                            "x": 452.4861241142277,
+                            "y": 72.56945212351388,
+                            "name": "parameter-string-json_path",
                             "alignment": "left",
-                            "parentNode": "3f7f910d-0199-4861-add9-70d855fef92c",
+                            "parentNode": "2bdec2e5-37f7-491d-a1eb-45643e1255f4",
                             "links": [
-                                "3479534e-4629-457e-b1c4-2c040d4a24c4"
+                                "3f7ee79a-ea70-4fd7-9f78-8c5585b71b6c"
                             ],
                             "in": true,
-                            "label": "★service_json_path",
-                            "varName": "★service_json_path",
+                            "label": "json_path",
+                            "varName": "json_path",
                             "portType": "",
                             "dataType": "string"
                         },
                         {
-                            "id": "8d8deb69-7834-47a8-b61e-4c0e29899fb9",
+                            "id": "1ea85e57-ff38-4a9e-947e-6262ab4aac58",
                             "type": "default",
                             "extras": {},
-                            "x": 630.4376230455367,
-                            "y": 50.69999135184526,
+                            "x": 600.9305567866924,
+                            "y": 50.79164773082521,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "3f7f910d-0199-4861-add9-70d855fef92c",
+                            "parentNode": "2bdec2e5-37f7-491d-a1eb-45643e1255f4",
                             "links": [
                                 "52f4085e-237d-43b9-ac10-769148722565"
                             ],
@@ -608,14 +606,14 @@
                             "dataType": ""
                         },
                         {
-                            "id": "423aeffb-a90d-4b86-b1a3-1df78ca40506",
+                            "id": "306bf460-3031-4d09-a49b-95984067ffa8",
                             "type": "default",
                             "extras": {},
-                            "x": 630.4376230455367,
-                            "y": 72.30001069883818,
+                            "x": 600.9305567866924,
+                            "y": 72.56945212351388,
                             "name": "parameter-out-any-gauth",
                             "alignment": "right",
-                            "parentNode": "3f7f910d-0199-4861-add9-70d855fef92c",
+                            "parentNode": "2bdec2e5-37f7-491d-a1eb-45643e1255f4",
                             "links": [],
                             "in": false,
                             "label": "gauth",
@@ -624,14 +622,14 @@
                             "dataType": "any"
                         },
                         {
-                            "id": "35b3e990-2e53-4fe2-a4aa-4976176e0d32",
+                            "id": "cf9e9da7-7e13-42c3-b62f-6cf83fa09cbc",
                             "type": "default",
                             "extras": {},
-                            "x": 630.4376230455367,
-                            "y": 93.89999549762945,
+                            "x": 600.9305567866924,
+                            "y": 94.34722196800092,
                             "name": "parameter-out-any-gdrive",
                             "alignment": "right",
-                            "parentNode": "3f7f910d-0199-4861-add9-70d855fef92c",
+                            "parentNode": "2bdec2e5-37f7-491d-a1eb-45643e1255f4",
                             "links": [
                                 "269702f1-96a0-431d-8f19-f7c28411d70b"
                             ],
@@ -643,21 +641,21 @@
                         }
                     ],
                     "name": "GDriveServiceAuth",
-                    "color": "rgb(51,51,51)",
+                    "color": "rgb(15,255,255)",
                     "portsInOrder": [
-                        "21a698b1-48ae-41f3-8b33-9b4820f501c3",
-                        "b2773a85-6773-4dd2-8f19-06848eb3aa63"
+                        "f4cf8ea6-4f2b-4c53-a863-5d50780048b0",
+                        "7d27ae2b-b234-4297-84d7-354d9e608544"
                     ],
                     "portsOutOrder": [
-                        "8d8deb69-7834-47a8-b61e-4c0e29899fb9",
-                        "423aeffb-a90d-4b86-b1a3-1df78ca40506",
-                        "35b3e990-2e53-4fe2-a4aa-4976176e0d32"
+                        "1ea85e57-ff38-4a9e-947e-6262ab4aac58",
+                        "306bf460-3031-4d09-a49b-95984067ffa8",
+                        "cf9e9da7-7e13-42c3-b62f-6cf83fa09cbc"
                     ]
                 },
-                "09859332-f868-4bb1-97ae-8e5bc811047b": {
-                    "id": "09859332-f868-4bb1-97ae-8e5bc811047b",
+                "91483558-f6f4-4691-8c48-c8e15d167a5e": {
+                    "id": "91483558-f6f4-4691-8c48-c8e15d167a5e",
                     "type": "custom-node",
-                    "selected": false,
+                    "selected": true,
                     "extras": {
                         "type": "string"
                     },
@@ -665,14 +663,14 @@
                     "y": 224.289641631916,
                     "ports": [
                         {
-                            "id": "42966bfc-57c6-44c9-bd20-e571e6abdc17",
+                            "id": "eb426bff-7942-4c5d-9ddb-3d83924e2e71",
                             "type": "default",
                             "extras": {},
-                            "x": 897.6250539491334,
-                            "y": 248.08751392333699,
+                            "x": 897.3611747849235,
+                            "y": 248.61109191935702,
                             "name": "parameter-out-0",
                             "alignment": "right",
-                            "parentNode": "09859332-f868-4bb1-97ae-8e5bc811047b",
+                            "parentNode": "91483558-f6f4-4691-8c48-c8e15d167a5e",
                             "links": [
                                 "77314daf-e058-4b70-95b4-efc34e225c9d"
                             ],
@@ -687,30 +685,31 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "42966bfc-57c6-44c9-bd20-e571e6abdc17"
+                        "eb426bff-7942-4c5d-9ddb-3d83924e2e71"
                     ]
                 },
-                "83598400-386b-4338-9768-22d9151bf20d": {
-                    "id": "83598400-386b-4338-9768-22d9151bf20d",
+                "f95cc405-f228-40c7-b404-b0b6f500cb80": {
+                    "id": "f95cc405-f228-40c7-b404-b0b6f500cb80",
                     "type": "custom-node",
-                    "selected": false,
+                    "selected": true,
                     "extras": {
-                        "type": "string"
+                        "type": "string",
+                        "borderColor": "rgb(0,192,255)"
                     },
                     "x": 226.3244408337148,
                     "y": 139.3839812545575,
                     "ports": [
                         {
-                            "id": "efad80e2-824f-466d-ae41-cd2574d0052b",
+                            "id": "d7d6bfed-44c3-411b-933c-63326006e99f",
                             "type": "default",
                             "extras": {},
-                            "x": 410.66248577401547,
-                            "y": 163.17497845384997,
+                            "x": 410.3749756398763,
+                            "y": 163.70829904273558,
                             "name": "parameter-out-0",
                             "alignment": "right",
-                            "parentNode": "83598400-386b-4338-9768-22d9151bf20d",
+                            "parentNode": "f95cc405-f228-40c7-b404-b0b6f500cb80",
                             "links": [
-                                "3479534e-4629-457e-b1c4-2c040d4a24c4"
+                                "3f7ee79a-ea70-4fd7-9f78-8c5585b71b6c"
                             ],
                             "in": false,
                             "label": "▶",
@@ -723,13 +722,13 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "efad80e2-824f-466d-ae41-cd2574d0052b"
+                        "d7d6bfed-44c3-411b-933c-63326006e99f"
                     ]
                 },
-                "106c857b-4c16-4808-829d-ea7cd94d6a6d": {
-                    "id": "106c857b-4c16-4808-829d-ea7cd94d6a6d",
+                "6b460be5-4d71-47e0-8450-b463c3de5554": {
+                    "id": "6b460be5-4d71-47e0-8450-b463c3de5554",
                     "type": "custom-node",
-                    "selected": false,
+                    "selected": true,
                     "extras": {
                         "type": "string",
                         "attached": false
@@ -738,14 +737,14 @@
                     "y": 312.1959622641509,
                     "ports": [
                         {
-                            "id": "ead1a4b1-040d-4881-913d-eedcfc9fed96",
+                            "id": "fe94a1e3-ba25-4d42-a01e-7e5d9b57290f",
                             "type": "default",
                             "extras": {},
-                            "x": 893.4625484214212,
-                            "y": 335.9875014859844,
+                            "x": 893.3055613931193,
+                            "y": 336.5277662634018,
                             "name": "out-0",
                             "alignment": "right",
-                            "parentNode": "106c857b-4c16-4808-829d-ea7cd94d6a6d",
+                            "parentNode": "6b460be5-4d71-47e0-8450-b463c3de5554",
                             "links": [
                                 "89d8304a-a302-4e6a-ade7-16e371415882"
                             ],
@@ -760,7 +759,7 @@
                     "color": "lightpink",
                     "portsInOrder": [],
                     "portsOutOrder": [
-                        "ead1a4b1-040d-4881-913d-eedcfc9fed96"
+                        "fe94a1e3-ba25-4d42-a01e-7e5d9b57290f"
                     ]
                 }
             }

--- a/gdrive_components.py
+++ b/gdrive_components.py
@@ -21,12 +21,12 @@ class GDriveServiceAuth(Component):
     ##### inPorts:
     - json_path: the path to the service account's secrets JSON file.
     """
-    json_path: InArg[str]
+    service_json_path: InArg[str]
     gauth: OutArg[any]
     gdrive: OutArg[any]
 
     def execute(self, ctx) -> None:
-        json_path = self.json_path.value
+        json_path = self.service_json_path.value
 
         if json_path and os.path.exists(json_path):
             print(f"Using provided service account JSON: {json_path}")
@@ -48,7 +48,7 @@ class GDriveServiceAuth(Component):
         settings = {
             "client_config_backend": "service",
             "service_config": {
-                "client_json_dict": gdrive_creds,
+                "client_json_file_path": self.service_json_path.value,
             }
         }
 


### PR DESCRIPTION


# Description

- Updated GDrive components to use `GOOGLE_SERVICE_ACCOUNT_CREDENTIALS` from environment variables for authentication.

## Pull Request Type

- [x] Xircuits Component Library Code
- [ ] Workflow Example
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update



## Tested on?

- [ ] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [x] Others  (on XpressAI platform )  


